### PR TITLE
[#29] CompletionReflectionView 구현

### DIFF
--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		264440532CD8B1540031A290 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440522CD8B1540031A290 /* String+Extension.swift */; };
+		264440552CD8E0100031A290 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440542CD8E0100031A290 /* KeyboardObserver.swift */; };
 		26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26890B942CAE811A008DFF49 /* FiveGuyesApp.swift */; };
 		26890B972CAE811A008DFF49 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26890B962CAE811A008DFF49 /* ContentView.swift */; };
 		26890B992CAE811D008DFF49 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26890B982CAE811D008DFF49 /* Assets.xcassets */; };
@@ -17,6 +18,7 @@
 
 /* Begin PBXFileReference section */
 		264440522CD8B1540031A290 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		264440542CD8E0100031A290 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		26890B912CAE811A008DFF49 /* FiveGuyes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FiveGuyes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26890B942CAE811A008DFF49 /* FiveGuyesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveGuyesApp.swift; sourceTree = "<group>"; };
 		26890B962CAE811A008DFF49 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 		26D853022CCE44720016239A /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				264440542CD8E0100031A290 /* KeyboardObserver.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -239,6 +242,7 @@
 				26890B972CAE811A008DFF49 /* ContentView.swift in Sources */,
 				26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */,
 				264440532CD8B1540031A290 /* String+Extension.swift in Sources */,
+				264440552CD8E0100031A290 /* KeyboardObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		264440532CD8B1540031A290 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440522CD8B1540031A290 /* String+Extension.swift */; };
 		264440552CD8E0100031A290 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440542CD8E0100031A290 /* KeyboardObserver.swift */; };
+		264440572CD8E0D20031A290 /* CustomTextEditorStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440562CD8E0D20031A290 /* CustomTextEditorStyle.swift */; };
 		26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26890B942CAE811A008DFF49 /* FiveGuyesApp.swift */; };
 		26890B972CAE811A008DFF49 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26890B962CAE811A008DFF49 /* ContentView.swift */; };
 		26890B992CAE811D008DFF49 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26890B982CAE811D008DFF49 /* Assets.xcassets */; };
@@ -19,6 +20,7 @@
 /* Begin PBXFileReference section */
 		264440522CD8B1540031A290 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		264440542CD8E0100031A290 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
+		264440562CD8E0D20031A290 /* CustomTextEditorStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextEditorStyle.swift; sourceTree = "<group>"; };
 		26890B912CAE811A008DFF49 /* FiveGuyes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FiveGuyes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26890B942CAE811A008DFF49 /* FiveGuyesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveGuyesApp.swift; sourceTree = "<group>"; };
 		26890B962CAE811A008DFF49 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 		26D853052CCE44970016239A /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				264440562CD8E0D20031A290 /* CustomTextEditorStyle.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -242,6 +245,7 @@
 				26890B972CAE811A008DFF49 /* ContentView.swift in Sources */,
 				26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */,
 				264440532CD8B1540031A290 /* String+Extension.swift in Sources */,
+				264440572CD8E0D20031A290 /* CustomTextEditorStyle.swift in Sources */,
 				264440552CD8E0100031A290 /* KeyboardObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		264440532CD8B1540031A290 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440522CD8B1540031A290 /* String+Extension.swift */; };
 		26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26890B942CAE811A008DFF49 /* FiveGuyesApp.swift */; };
 		26890B972CAE811A008DFF49 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26890B962CAE811A008DFF49 /* ContentView.swift */; };
 		26890B992CAE811D008DFF49 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26890B982CAE811D008DFF49 /* Assets.xcassets */; };
@@ -15,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		264440522CD8B1540031A290 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		26890B912CAE811A008DFF49 /* FiveGuyes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FiveGuyes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26890B942CAE811A008DFF49 /* FiveGuyesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveGuyesApp.swift; sourceTree = "<group>"; };
 		26890B962CAE811A008DFF49 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 		26D853002CCE44600016239A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				264440522CD8B1540031A290 /* String+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -235,6 +238,7 @@
 			files = (
 				26890B972CAE811A008DFF49 /* ContentView.swift in Sources */,
 				26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */,
+				264440532CD8B1540031A290 /* String+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		264440502CD8A3AC0031A290 /* CompletionReflectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2644404F2CD8A3AC0031A290 /* CompletionReflectionView.swift */; };
 		264440532CD8B1540031A290 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440522CD8B1540031A290 /* String+Extension.swift */; };
 		264440552CD8E0100031A290 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440542CD8E0100031A290 /* KeyboardObserver.swift */; };
 		264440572CD8E0D20031A290 /* CustomTextEditorStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264440562CD8E0D20031A290 /* CustomTextEditorStyle.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2644404F2CD8A3AC0031A290 /* CompletionReflectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionReflectionView.swift; sourceTree = "<group>"; };
 		264440522CD8B1540031A290 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		264440542CD8E0100031A290 /* KeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		264440562CD8E0D20031A290 /* CustomTextEditorStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextEditorStyle.swift; sourceTree = "<group>"; };
@@ -40,6 +42,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		264440512CD8A3B50031A290 /* BookCompletion */ = {
+			isa = PBXGroup;
+			children = (
+				2644404F2CD8A3AC0031A290 /* CompletionReflectionView.swift */,
+			);
+			path = BookCompletion;
+			sourceTree = "<group>";
+		};
 		26890B882CAE811A008DFF49 = {
 			isa = PBXGroup;
 			children = (
@@ -118,6 +128,7 @@
 		26D852FB2CCE40BC0016239A /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				264440512CD8A3B50031A290 /* BookCompletion */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -243,6 +254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				26890B972CAE811A008DFF49 /* ContentView.swift in Sources */,
+				264440502CD8A3AC0031A290 /* CompletionReflectionView.swift in Sources */,
 				26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */,
 				264440532CD8B1540031A290 /* String+Extension.swift in Sources */,
 				264440572CD8E0D20031A290 /* CustomTextEditorStyle.swift in Sources */,

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/String+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/String+Extension.swift
@@ -1,0 +1,34 @@
+//
+//  String+Extension.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 11/4/24.
+//
+
+//import Foundation
+
+extension String {
+    func postPositionParticle() -> String {
+        guard let lastCharacter = self.last else { return "를" }
+        
+        // 마지막 문자의 유니코드 값 추출
+        guard let unicodeValue = UnicodeScalar(String(lastCharacter))?.value else { return "를" }
+        
+        // 숫자인 경우
+        if lastCharacter.isNumber, let lastDigit = Int(String(lastCharacter)) {
+            let numbersWithFinalConsonant = [0, 1, 3, 6, 7, 8]
+            return numbersWithFinalConsonant.contains(lastDigit) ? "을" : "를"
+        }
+        
+        // 영어 문자일 경우
+        if unicodeValue < 0xAC00 || unicodeValue > 0xD7A3 {
+            let lastLowercased = lastCharacter.lowercased()
+            let koreanConsonantAlphabets = ["l", "m", "n", "r"]
+            return koreanConsonantAlphabets.contains(lastLowercased) ? "을" : "를"
+        }
+        
+        // 한글 문자일 경우
+        let finalConsonant = (unicodeValue - 0xAC00) % 28
+        return finalConsonant > 0 ? "을" : "를"
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Stores/KeyboardObserver.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Stores/KeyboardObserver.swift
@@ -1,0 +1,36 @@
+//
+//  KeyboardObserver.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 11/4/24.
+//
+
+import UIKit
+
+class KeyboardObserver: ObservableObject {
+    @Published var keyboardIsVisible: Bool = false
+    
+    init() {
+        addKeyboardObservers()
+    }
+    
+    deinit {
+        removeKeyboardObservers()
+        print("KeyboardObserver 해제됨")
+    }
+    
+    private func addKeyboardObservers() {
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { _ in
+            self.keyboardIsVisible = true
+        }
+        
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+            self.keyboardIsVisible = false
+        }
+    }
+    
+    private func removeKeyboardObservers() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Views/Components/CustomTextEditorStyle.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Components/CustomTextEditorStyle.swift
@@ -1,0 +1,46 @@
+//
+//  CustomTextEditorStyle.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 11/4/24.
+//
+
+import SwiftUI
+
+struct CustomTextEditorStyle: ViewModifier {
+    let placeholder: String
+    @Binding var text: String
+    
+    func body(content: Content) -> some View {
+        content
+            .padding(.vertical, 22)
+            .padding(.horizontal, 20)
+            .overlay(alignment: .topLeading) {
+                placeholderView()
+            }
+            .textInputAutocapitalization(.none) // 첫 시작 대문자 막기
+            .autocorrectionDisabled()
+            .background(Color(red: 0.93, green: 0.97, blue: 0.95))
+            .opacity(0.8)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .scrollContentBackground(.hidden)
+            .font(.system(size: 14))
+    }
+    
+    @ViewBuilder
+    private func placeholderView() -> some View {
+        if text.isEmpty {
+            Text(placeholder)
+                .padding(.top, 30)
+                .padding(.leading, 27)
+                .font(.system(size: 14))
+                .foregroundColor(.gray)
+        }
+    }
+}
+
+extension TextEditor {
+    func customStyleEditor(placeholder: String, userInput: Binding<String>) -> some View {
+        self.modifier(CustomTextEditorStyle(placeholder: placeholder, text: userInput))
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookCompletion/CompletionReflectionView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookCompletion/CompletionReflectionView.swift
@@ -1,0 +1,61 @@
+//
+//  CompletionReflectionView.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 11/4/24.
+//
+
+import SwiftUI
+
+struct CompletionReflectionView: View {
+    private let bookName = "프리웨이"
+    private let placeholder: String = "책 속 한 줄이 남긴 여운은 무엇인가요?"
+    
+    @State private var reflectionText: String = ""
+    @FocusState private var isFocusedTextEditor: Bool
+    @ObservedObject private var keyboardObserver = KeyboardObserver()
+    
+    // TODO: Font, Color 설정
+    var body: some View {
+        ZStack {
+            Color.white.ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 24) {
+                    Text("<\(bookName)>\(bookName.postPositionParticle()) 완독하고...\n어떤 영감을 얻었나요?")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(.black)
+                    
+                    TextEditor(text: $reflectionText)
+                        .customStyleEditor(placeholder: placeholder, userInput: $reflectionText)
+                        .frame(height: 222)
+                        .focused($isFocusedTextEditor)
+                }
+                .padding(20)
+                
+                Spacer()
+                
+                if keyboardObserver.keyboardIsVisible {
+                    Button {
+                        print("clicked")
+                    } label: {
+                        Text("저장")
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(.green)
+                            .foregroundStyle(.white)
+                        
+                    }
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
+                }
+            }
+        }
+        .onAppear {
+            isFocusedTextEditor = true
+        }
+    }
+}
+
+#Preview {
+    CompletionReflectionView()
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- CompletionReflectionView 구현하여 사용자가 책 완독 후 감상을 작성할 수 있도록 추가
- 커스텀 TextEditor 스타일 모디파이어 추가로, placeholder와 스타일 지정 가능
- KeyboardObserver를 통해 키보드 표시 상태를 감지하고, 키보드가 나타날 때 저장 버튼이 화면에 표시되도록 설정
- 뷰가 등장하자마자 키보드가 자동으로 올라가도록 포커스 설정

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/198c01ce-2658-413c-82c4-4566a6dbacb3" width="300"/>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- CompletionReflectionView의 이름이 적절한지 고민입니다!
 (완독을 completion으로, 감상을 reflection으로 표현하고 있습니다. 다른 대체 명칭이 더 자연스러운지 의견 부탁드립니다.)
