### PR TITLE
[#62] 백 버튼의 탭 가능 영역 확장

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Views/Shared/CustomBackButton.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Shared/CustomBackButton.swift
@@ -10,19 +10,21 @@ import SwiftUI
 struct CustomBackButton: View {
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     
-    //TODO: tint 색 변경하기
     var body: some View {
-        Button {
-            presentationMode.wrappedValue.dismiss()
-        } label: {
-            HStack {
-                Image(systemName: "chevron.left")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 20)
-                    .tint(.gray)
+        HStack {
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                HStack {
+                    Image(systemName: "chevron.left")
+                        .resizable()
+                        .scaledToFit()
+                        .tint(Color(red: 0.12, green: 0.12, blue: 0.12))
+                }
             }
+            Spacer()
         }
+        .background(.white)
     }
 }
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 사용자 편의성을 위해 백 버튼의 tappable 영역을 확대합니다.
- 작은 영역으로 인해 발생할 수 있는 터치 오류를 방지합니다.

### 스크린샷 (선택)
#### Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7035a468-ff30-480f-83b1-ec74f3a0d5ca">

#### After
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2de295ab-90d1-45f1-9aa9-c0c116a1e14e">

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 
