### PR TITLE
[#106] 페이지 계산 시 초기 페이지가 0으로 설정되는 이슈 해결

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -18,7 +18,7 @@ struct ReadingScheduleCalculator {
         
         var targetDate = settings.startDate
         var remainderOffset = remainderPages
-        var cumulativePages = 0
+        var cumulativePages = settings.startPage
         
         // 비독서일을 제외하고 읽어야 할 페이지를 초기 할당
         while progress.getReadingRecordsKey(targetDate) <= progress.getReadingRecordsKey(settings.targetEndDate) {
@@ -37,15 +37,11 @@ struct ReadingScheduleCalculator {
         while remainderOffset > 0 {
             let dateKey = progress.getReadingRecordsKey(remainderTargetDate)
             guard var record = progress.readingRecords[dateKey] else { return }
-            record.targetPages += 1
+            record.targetPages += remainderOffset
             progress.readingRecords[dateKey] = record
             remainderOffset -= 1
             remainderTargetDate = Calendar.current.date(byAdding: .day, value: -1, to: remainderTargetDate)!
         }
-        
-        // 초기화 시 읽은 페이지 관련 데이터 초기 설정
-        progress.lastReadDate = nil
-        progress.lastPagesRead = 0
     }
     
     ///  읽은 페이지 입력 메서드 (오늘 날짜에만 값을 넣을 수 있음)
@@ -114,7 +110,7 @@ struct ReadingScheduleCalculator {
             let dateKey = progress.getReadingRecordsKey(remainingTargetDate)
             
             guard var record = progress.readingRecords[dateKey] else { return }
-            record.targetPages += 1
+            record.targetPages += remainderOffset
             progress.readingRecords[dateKey] = record
             remainderOffset -= 1
             
@@ -157,7 +153,7 @@ struct ReadingScheduleCalculator {
             let dateKey = progress.getReadingRecordsKey(remainingTargetDate)
             guard var record = progress.readingRecords[dateKey] else { return }
             
-            record.targetPages += 1
+            record.targetPages += remainderOffset
             progress.readingRecords[dateKey] = record
             remainderOffset -= 1
             remainingTargetDate = Calendar.current.date(byAdding: .day, value: -1, to: remainingTargetDate)!
@@ -204,7 +200,7 @@ struct ReadingScheduleCalculator {
         let totalReadingDays = firstCalculateTotalReadingDays(settings: settings, progress: progress)
         
         // 총 페이지 수와 하루 할당량 계산
-        let totalPages = settings.targetEndPage - settings.startPage + 1
+        let totalPages = settings.targetEndPage - settings.startPage
         let pagesPerDay = totalPages / totalReadingDays
         let remainder = totalPages % totalReadingDays
         

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/FinishGoalView.swift
@@ -171,7 +171,7 @@ struct FinishGoalView: View {
                 // TODO: 해당 모델 객체를 더 잘 만들 방식 고민하기
                 let bookMetaData = BookMetaData(title: book.title, author: book.author, coverURL: book.cover, totalPages: totalPages)
                 var userSettings = UserSettings(startPage: startPage, targetEndPage: totalPages, startDate: startDate, targetEndDate: endDate, nonReadingDays: bookSettingInputModel.nonReadingDays)
-                var readingProgress = ReadingProgress()
+                let readingProgress = ReadingProgress(lastPagesRead: startPage)
                 let completionStatus = CompletionStatus()
   
                 calculator.calculateInitialDailyTargets(for: userSettings, progress: readingProgress)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 초기 페이지 계산 시 기존 로직에서는 첫 페이지를 커스텀할 수 있는 기능이 없어서, 로직이 끝난 뒤 0으로 재할당해야 했습니다. 현재는 해당 로직이 필요하지 않아서 삭제했습니다.
- 페이지 계산 시 남은 페이지를 뒤에서부터 할당할 때, 앞에서의 페이지 추가를 고려하여 1씩 더하는 대신 나머지 값을 전체적으로 더한 후, -1씩 감소시키는 방식으로 변경했습니다.
	- 초기 할당 예시: 100, 200, 300, 남은 페이지: 5
	- 최종 할당 예시: 103, 204, 305 (매일 101페이지씩 읽도록 계산)

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/6ddc14cd-b1d0-465f-aa0c-27992f60f77f" width="300"/>


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- **페이지 계산 로직의 가독성:**
한 메서드가 너무 길어, 중간에 0으로 재할당하는 로직을 쉽게 찾기 어려웠습니다. 메서드를 분리하거나 중복되는 로직을 재활용할 수 있도록 리팩토링이 필요해 보입니다.
- **테스트 코드 작성:**
페이지 계산의 경우 첫 페이지, 마지막 페이지, 그리고 읽는 날만 명확히 정의되면 예상 결과를 쉽게 검증할 수 있습니다. 이에 맞는 테스트 코드를 작성하면 향후 유지보수와 작업 효율성이 더 좋아질 것 같습니다.
