### PR TITLE
[#120] 오늘 날짜가 시작일 이전일 경우 기록 누락 문제 해결

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
@@ -51,8 +51,13 @@ final class ReadingProgress: ReadingProgressProtocol {
         let firstDate = settings.startDate
         let lastDate = settings.targetEndDate
         
+        let today = Date()
+
+        // 오늘이 시작일보다 이전일 경우 처리
+        let effectiveStartDay = today < firstDate ? today : firstDate
+        
         let calendar = Calendar.current
-        let firstWeekStart = calendar.dateInterval(of: .weekOfMonth, for: firstDate)?.start ?? firstDate
+        let firstWeekStart = calendar.dateInterval(of: .weekOfMonth, for: effectiveStartDay)?.start ?? firstDate
         let lastWeekStart = calendar.dateInterval(of: .weekOfMonth, for: lastDate)?.start ?? lastDate
         
         var startDates: [Date] = []

--- a/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyPageCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyPageCalendarView.swift
@@ -122,7 +122,7 @@ struct WeeklyPageCalendarView: View {
             if isLastDay(weekPageIndex: weekPageIndex, dayIndex: dayIndex) {
                 // 마지막 날 이미지 표시
                 completionImage
-            } else if let record {
+            } else {
                 // 일반 텍스트 표시
                 textForCurrentWeek(record, dayIndex: dayIndex, todayIndex: todayIndex)
             }
@@ -249,7 +249,9 @@ struct WeeklyPageCalendarView: View {
                         .foregroundStyle(Color.Labels.secondaryBlack2)
                 }
             } else {
-                Text("")
+                    if dayIndex == todayIndex {
+                        Circle().fill(Color.Separators.green)
+                }
             }
         }
     }

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/CompletionCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/CompletionCalendarView.swift
@@ -25,10 +25,6 @@ struct CompletionCalendarView: View {
     @State private var isDateSelectionLocked = false
     @State private var isFirstClick = true
     
-    // MARK: 추가된 변수
-//    @State private var pagesPerDay = 0
-//    @State private var dayCount = 0
-    
     private var dayCount: Int {
         Calendar.current.getDateGap(from: startDate, to: endDate)
     }
@@ -120,6 +116,7 @@ struct CompletionCalendarView: View {
             nextButton()
                 .padding(.horizontal, 16)
         }
+        .animation(.easeIn, value: isFirstClick)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 오늘 날짜가 책 읽기 시작일(startDay)보다 이전인 경우 오늘부터 데이터를 가져오도록 로직 수정
- 책 읽기 시작일 이후라면 기존 로직대로 startDay부터 데이터를 가져오도록 처리
- CompletionCalendarView에서 날짜 비교 및 데이터 계산 로직 개선

