### PR TITLE
[#125] 읽기 진행 로직 및 캘린더 UI 수정

### DIFF
--- a/FiveGuyes/FiveGuyes/.swiftlint.yml
+++ b/FiveGuyes/FiveGuyes/.swiftlint.yml
@@ -31,7 +31,7 @@ line_length: # From https://realm.github.io/SwiftLint/line_length.html
 # 함수 본문 길이 제한
 function_body_length: # From https://realm.github.io/SwiftLint/function_body_length.html
     warning: 15 # 함수 본문이 15줄을 넘을 경우 warning
-    error: 30 # 함수 본문이 30줄을 넘을 경우 error
+    error: 50 # 함수 본문이 30줄을 넘을 경우 error
 
 # 클래스, 구조체, 열거형의 본문 길이 제한
 type_body_length: # From https://realm.github.io/SwiftLint/type_body_length.html

--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -71,6 +71,9 @@ struct ReadingScheduleCalculator {
         record.pagesRead = pagesRead
         progress.readingRecords[dateKey] = record
         
+        progress.lastPagesRead = pagesRead
+        progress.lastReadDate = today.adjustedDate()
+        
         // 목표량과 실제 읽은 페이지 수가 다르면 이후 날짜 조정
         if record.pagesRead != record.targetPages {
             adjustFutureTargets(for: settings, progress: progress, from: today)

--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -53,6 +53,11 @@ struct ReadingScheduleCalculator {
     ) {
         let dateKey = progress.getAdjustedReadingRecordsKey(today)
         
+        // 시작날짜보다 오늘 날짜가 이전이면
+        if settings.startDate > today {
+            settings.changeStartDate(for: today)
+        }
+        
         var record = progress.readingRecords[dateKey, default: ReadingRecord(targetPages: 0, pagesRead: 0)]
         
         // 비독서일에서 해당 날짜 제거

--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -76,6 +76,7 @@ struct ReadingScheduleCalculator {
         
         // 목표량과 실제 읽은 페이지 수가 다르면 이후 날짜 조정
         if record.pagesRead != record.targetPages {
+            progress.readingRecords[dateKey]?.targetPages = record.pagesRead
             adjustFutureTargets(for: settings, progress: progress, from: today)
         }
     }

--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -101,24 +101,27 @@ struct ReadingScheduleCalculator {
             if !settings.nonReadingDays
                 .map({ progress.getReadingRecordsKey($0) })
                 .contains(dateKey) {
-                guard var record = progress.readingRecords[dateKey] else { return }
+                guard var record = progress.readingRecords[dateKey] else {
+                    nextDate = Calendar.current.date(byAdding: .day, value: 1, to: nextDate)!
+                    continue
+                }
                 cumulativePages += pagesPerDay
                 record.targetPages = cumulativePages
                 progress.readingRecords[dateKey] = record
             }
-            
             nextDate = Calendar.current.date(byAdding: .day, value: 1, to: nextDate)!
         }
         
         var remainingTargetDate = settings.targetEndDate
         while remainderOffset > 0 {
             let dateKey = progress.getReadingRecordsKey(remainingTargetDate)
-            
-            guard var record = progress.readingRecords[dateKey] else { return }
+            guard var record = progress.readingRecords[dateKey] else {
+                remainingTargetDate = Calendar.current.date(byAdding: .day, value: -1, to: nextDate)!
+                continue
+            }
             record.targetPages += remainderOffset
             progress.readingRecords[dateKey] = record
             remainderOffset -= 1
-            
             remainingTargetDate = Calendar.current.date(byAdding: .day, value: -1, to: remainingTargetDate)!
         }
     }
@@ -156,7 +159,10 @@ struct ReadingScheduleCalculator {
         var remainingTargetDate = settings.targetEndDate
         while remainderOffset > 0 {
             let dateKey = progress.getReadingRecordsKey(remainingTargetDate)
-            guard var record = progress.readingRecords[dateKey] else { return }
+            guard var record = progress.readingRecords[dateKey] else {
+                remainingTargetDate = Calendar.current.date(byAdding: .day, value: -1, to: remainingTargetDate)!
+                continue
+            }
             
             record.targetPages += remainderOffset
             progress.readingRecords[dateKey] = record
@@ -230,6 +236,11 @@ struct ReadingScheduleCalculator {
         
         while progress.getAdjustedReadingRecordsKey(targetDate) <= progress.getReadingRecordsKey(settings.targetEndDate) {
             let dateKey = progress.getAdjustedReadingRecordsKey(targetDate)
+            guard progress.readingRecords[dateKey] != nil else {
+                targetDate = Calendar.current.date(byAdding: .day, value: 1, to: targetDate)!
+                continue
+            }
+            
             if !settings.nonReadingDays
                 .map({ progress.getReadingRecordsKey($0) })
                 .contains(dateKey) {

--- a/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
@@ -51,13 +51,13 @@ final class ReadingProgress: ReadingProgressProtocol {
         let firstDate = settings.startDate
         let lastDate = settings.targetEndDate
         
-        let today = Date()
+        let today = Date().adjustedDate()
 
         // 오늘이 시작일보다 이전일 경우 처리
         let effectiveStartDay = today < firstDate ? today : firstDate
         
         let calendar = Calendar.current
-        let firstWeekStart = calendar.dateInterval(of: .weekOfMonth, for: effectiveStartDay)?.start ?? firstDate
+        let firstWeekStart = calendar.dateInterval(of: .weekOfMonth, for: effectiveStartDay)?.start ?? effectiveStartDay
         let lastWeekStart = calendar.dateInterval(of: .weekOfMonth, for: lastDate)?.start ?? lastDate
         
         var startDates: [Date] = []

--- a/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/UserSettings.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/UserSettings.swift
@@ -23,4 +23,8 @@ final class UserSettings: UserSettingsProtocol {
         self.targetEndDate = targetEndDate
         self.nonReadingDays = nonReadingDays
     }
+    
+    func changeStartDate(for date: Date) {
+        self.startDate = date
+    }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Protocols/UserSettingsProtocol.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Protocols/UserSettingsProtocol.swift
@@ -13,4 +13,6 @@ protocol UserSettingsProtocol: AnyObject {
     var startDate: Date { get }
     var targetEndDate: Date { get set }
     var nonReadingDays: [Date] { get set }
+    
+    func changeStartDate(for date: Date)
 }

--- a/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyPageCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyPageCalendarView.swift
@@ -5,15 +5,17 @@
 //  Created by zaehorang on 11/6/24.
 //
 
+import SwiftData
 import SwiftUI
 
 struct WeeklyPageCalendarView: View {
     typealias UserBook = UserBookSchemaV2.UserBookV2
     
     let daysOfWeek = ["일", "월", "화", "수", "목", "금", "토"]
-    let currentReadingBook: UserBook
+    @Query(filter: #Predicate<UserBook> { $0.completionStatus.isCompleted == false })
+    private var currentlyReadingBooks: [UserBook]  // 현재 읽고 있는 책을 가져오는 쿼리
     
-    let today = Date()
+    let today = Date().adjustedDate()
     
     @State private var allWeekStartDates: [Date] = []
     @State private var currentWeekPageIndex: Int = 0
@@ -24,6 +26,7 @@ struct WeeklyPageCalendarView: View {
     @State private var lastDayIndex = 0
     
     var body: some View {
+        let currentReadingBook = currentlyReadingBooks.first ?? UserBook.dummyUserBookV2
         
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {

--- a/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyReadingProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyReadingProgressView.swift
@@ -53,7 +53,7 @@ struct WeeklyReadingProgressView: View {
                 .padding(.top, 22)
                 .padding(.horizontal, 24)
                 
-                WeeklyPageCalendarView(currentReadingBook: currentReadingBook)
+                WeeklyPageCalendarView()
                     .padding(.horizontal, 14)
                     .padding(.bottom, 18)
                 

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/Main/MainHomeView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/Main/MainHomeView.swift
@@ -137,6 +137,13 @@ struct MainHomeView: View {
                 let readingScheduleCalculator = ReadingScheduleCalculator()
                 print("🌝🌝🌝🌝🌝 재할당!!")
                 readingScheduleCalculator.reassignPagesFromLastReadDate(settings: currentReadingBook.userSettings, progress: currentReadingBook.readingProgress)
+                
+                // 데이저 저장이 느려서 직접 저장해주기
+                do {
+                    try modelContext.save()
+                } catch {
+                    print(error.localizedDescription)
+                }
             }
         }
         .onAppear {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- SwiftData 수동 저장 로직 추가
- 책 데이터 SwiftData에서 직접 불러오도록 수정
- 읽기 시작 날짜 조정 로직 추가
- 반복문에서 return을 continue로 변경
- 목표 페이지와 실제 읽은 페이지 동기화
- 시작 날짜가 미래인 경우 캘린더 첫 주를 오늘 기준으로 표시

### 스크린샷 (선택)
- 입력 전
<img src="https://github.com/user-attachments/assets/1ff2b0d0-aa9d-4daa-ac43-55309fa59707" width="200"/>
<img src="https://github.com/user-attachments/assets/08138324-2b05-49cf-afcf-11705e2b15d0" width="200"/>

- 입력 후
<img src="https://github.com/user-attachments/assets/b37657f0-80e2-46c7-8ef5-42b2aa9597cf" width="200"/>
<img src="https://github.com/user-attachments/assets/5d2c0a91-d005-40ec-968c-2db377d44cc5" width="200"/>
<img src="https://github.com/user-attachments/assets/36c1dbac-ec98-4d23-9d23-4cb99a2447aa" width="200"/>
