### PR TITLE
[#137] 캘린더뷰 셀 뒷배경 수정

### DIFF
--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -794,7 +794,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.FiveNorms.FiveNorms;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -834,7 +834,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.FiveNorms.FiveNorms;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/CompletionCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/CompletionCalendarView.swift
@@ -243,7 +243,7 @@ struct CompletionCalendarView: View {
                     
                     Rectangle()
                         .fill(Color.Fills.lightGreen)
-                        .frame(height: 44)
+                        .frame(width: 22, height: 44)
                 }
                 // 선택된 종료 날짜
                 else if let end = endDate, date == end {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 캘린더 뷰에서 시작 날짜와 종료 날짜 셀의 뒷 배경 컬러를 수정합니다.
- 빠른 업데이트를 위해 프로젝트 버전을 1.3.2로 올립니다.

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/d806e2bf-e47b-45c5-bd7d-b0473cfb391f" width="300"/>
