### PR TITLE
[#145]  Calculator 구조체 도입 및 ReadingScheduleCalculator 리팩터링

### DIFF
--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -43,6 +43,8 @@
 		26890B992CAE811D008DFF49 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26890B982CAE811D008DFF49 /* Assets.xcassets */; };
 		26890B9C2CAE811D008DFF49 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26890B9B2CAE811D008DFF49 /* Preview Assets.xcassets */; };
 		26890BBD2CAE98E2008DFF49 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 26890BBC2CAE98E2008DFF49 /* .swiftlint.yml */; };
+		26CF82582D1D3216005037E4 /* ReadingDateCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CF82572D1D3216005037E4 /* ReadingDateCalculator.swift */; };
+		26CF825A2D1D4B09005037E4 /* ReadingPagesCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CF82592D1D4B09005037E4 /* ReadingPagesCalculator.swift */; };
 		26EBDE262CDE3C6000B3A2BC /* BookSettingInputModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EBDE252CDE3C6000B3A2BC /* BookSettingInputModel.swift */; };
 		26EBDE2A2CDF33D900B3A2BC /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EBDE292CDF33D900B3A2BC /* Date+Extension.swift */; };
 		26EBDE2C2CE1341800B3A2BC /* ReadingRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EBDE2B2CE1341800B3A2BC /* ReadingRecord.swift */; };
@@ -83,6 +85,16 @@
 		26F19A7A2CDB5F3900F41D6D /* ReadingScheduleCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F19A792CDB5F3900F41D6D /* ReadingScheduleCalculator.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		26CF82632D1D4D4D005037E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 26890B892CAE811A008DFF49 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 26890B902CAE811A008DFF49;
+			remoteInfo = FiveGuyes;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		1A010EAB2CD8A7E500FBE3B3 /* APIBooksModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBooksModel.swift; sourceTree = "<group>"; };
 		1A010EAD2CD8A86E00FBE3B3 /* APIStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIStore.swift; sourceTree = "<group>"; };
@@ -121,6 +133,9 @@
 		26890B982CAE811D008DFF49 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		26890B9B2CAE811D008DFF49 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		26890BBC2CAE98E2008DFF49 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		26CF82572D1D3216005037E4 /* ReadingDateCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDateCalculator.swift; sourceTree = "<group>"; };
+		26CF82592D1D4B09005037E4 /* ReadingPagesCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPagesCalculator.swift; sourceTree = "<group>"; };
+		26CF825F2D1D4D4D005037E4 /* ReadingDateCalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReadingDateCalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		26EBDE252CDE3C6000B3A2BC /* BookSettingInputModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSettingInputModel.swift; sourceTree = "<group>"; };
 		26EBDE292CDF33D900B3A2BC /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		26EBDE2B2CE1341800B3A2BC /* ReadingRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingRecord.swift; sourceTree = "<group>"; };
@@ -156,6 +171,10 @@
 		26F19A792CDB5F3900F41D6D /* ReadingScheduleCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingScheduleCalculator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		26CF82602D1D4D4D005037E4 /* ReadingDateCalculatorTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ReadingDateCalculatorTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		26890B8E2CAE811A008DFF49 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -167,6 +186,13 @@
 				26EBDEB22CF1C5C900B3A2BC /* FirebaseRemoteConfig in Frameworks */,
 				26EBDEAC2CF1C5C900B3A2BC /* FirebaseDynamicLinks in Frameworks */,
 				26EBDEAE2CF1C5C900B3A2BC /* FirebaseInAppMessaging-Beta in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		26CF825C2D1D4D4D005037E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,6 +249,7 @@
 			children = (
 				24F8A2162CEB290B00A01A76 /* Config.xcconfig */,
 				26890B932CAE811A008DFF49 /* FiveGuyes */,
+				26CF82602D1D4D4D005037E4 /* ReadingDateCalculatorTests */,
 				26890B922CAE811A008DFF49 /* Products */,
 				26EBDE2D2CE3307C00B3A2BC /* Recovered References */,
 			);
@@ -232,6 +259,7 @@
 			isa = PBXGroup;
 			children = (
 				26890B912CAE811A008DFF49 /* FiveGuyes.app */,
+				26CF825F2D1D4D4D005037E4 /* ReadingDateCalculatorTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -272,6 +300,7 @@
 			isa = PBXGroup;
 			children = (
 				26EBDEC82CF4553D00B3A2BC /* SwiftDataMigration */,
+				26CF82562D1D3205005037E4 /* Utils */,
 				26D853032CCE44730016239A /* Models */,
 				26D853022CCE44720016239A /* Stores */,
 				26890BB12CAE90E4008DFF49 /* Views */,
@@ -290,6 +319,15 @@
 				26D853042CCE44950016239A /* Shared */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		26CF82562D1D3205005037E4 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				26CF82572D1D3216005037E4 /* ReadingDateCalculator.swift */,
+				26CF82592D1D4B09005037E4 /* ReadingPagesCalculator.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		26D852F92CCE40930016239A /* Navigation */ = {
@@ -511,6 +549,29 @@
 			productReference = 26890B912CAE811A008DFF49 /* FiveGuyes.app */;
 			productType = "com.apple.product-type.application";
 		};
+		26CF825E2D1D4D4D005037E4 /* ReadingDateCalculatorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 26CF82652D1D4D4D005037E4 /* Build configuration list for PBXNativeTarget "ReadingDateCalculatorTests" */;
+			buildPhases = (
+				26CF825B2D1D4D4D005037E4 /* Sources */,
+				26CF825C2D1D4D4D005037E4 /* Frameworks */,
+				26CF825D2D1D4D4D005037E4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				26CF82642D1D4D4D005037E4 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				26CF82602D1D4D4D005037E4 /* ReadingDateCalculatorTests */,
+			);
+			name = ReadingDateCalculatorTests;
+			packageProductDependencies = (
+			);
+			productName = ReadingDateCalculatorTests;
+			productReference = 26CF825F2D1D4D4D005037E4 /* ReadingDateCalculatorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -518,11 +579,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1520;
+				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					26890B902CAE811A008DFF49 = {
 						CreatedOnToolsVersion = 15.2;
+					};
+					26CF825E2D1D4D4D005037E4 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 26890B902CAE811A008DFF49;
 					};
 				};
 			};
@@ -544,6 +609,7 @@
 			projectRoot = "";
 			targets = (
 				26890B902CAE811A008DFF49 /* FiveGuyes */,
+				26CF825E2D1D4D4D005037E4 /* ReadingDateCalculatorTests */,
 			);
 		};
 /* End PBXProject section */
@@ -560,6 +626,13 @@
 				26890BBD2CAE98E2008DFF49 /* .swiftlint.yml in Resources */,
 				26890B9C2CAE811D008DFF49 /* Preview Assets.xcassets in Resources */,
 				26890B992CAE811D008DFF49 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		26CF825D2D1D4D4D005037E4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -638,11 +711,13 @@
 				1AA14A7A2CDDD96200B763A6 /* NotificationManager.swift in Sources */,
 				24FAF9452CEC5224004FEC3F /* ToastView.swift in Sources */,
 				26EBDE912CF068E600B3A2BC /* FontStyle.swift in Sources */,
+				26CF825A2D1D4B09005037E4 /* ReadingPagesCalculator.swift in Sources */,
 				264440502CD8A3AC0031A290 /* CompletionReviewView.swift in Sources */,
 				26EBDEBE2CF2390C00B3A2BC /* CompletionStatusProtocol.swift in Sources */,
 				264440502CD8A3AC0031A290 /* CompletionReviewView.swift in Sources */,
 				2655532F2CF6D73900288037 /* NotiSettingView.swift in Sources */,
 				26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */,
+				26CF82582D1D3216005037E4 /* ReadingDateCalculator.swift in Sources */,
 				26EBDE992CF07A7900B3A2BC /* FontWeight.swift in Sources */,
 				26EBDE972CF0764A00B3A2BC /* FontModifier.swift in Sources */,
 				26F19A6E2CDA74A600F41D6D /* WeeklyPageCalendarView.swift in Sources */,
@@ -660,12 +735,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		26CF825B2D1D4D4D005037E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		26890BBB2CAE9896008DFF49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = 26890BBA2CAE9896008DFF49 /* SwiftLintBuildToolPlugin */;
+		};
+		26CF82642D1D4D4D005037E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 26890B902CAE811A008DFF49 /* FiveGuyes */;
+			targetProxy = 26CF82632D1D4D4D005037E4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -876,6 +963,54 @@
 			};
 			name = Release;
 		};
+		26CF82662D1D4D4D005037E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LYC8XX4ZNC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FiveGuyes.ReadingDateCalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FiveGuyes.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/FiveGuyes";
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		26CF82672D1D4D4D005037E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LYC8XX4ZNC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FiveGuyes.ReadingDateCalculatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FiveGuyes.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/FiveGuyes";
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -893,6 +1028,15 @@
 			buildConfigurations = (
 				26890BA02CAE811D008DFF49 /* Debug */,
 				26890BA12CAE811D008DFF49 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		26CF82652D1D4D4D005037E4 /* Build configuration list for PBXNativeTarget "ReadingDateCalculatorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				26CF82662D1D4D4D005037E4 /* Debug */,
+				26CF82672D1D4D4D005037E4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FiveGuyes/FiveGuyes.xcodeproj/xcshareddata/xcschemes/FiveGuyes.xcscheme
+++ b/FiveGuyes/FiveGuyes.xcodeproj/xcshareddata/xcschemes/FiveGuyes.xcscheme
@@ -28,6 +28,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "26CF825E2D1D4D4D005037E4"
+               BuildableName = "ReadingDateCalculatorTests.xctest"
+               BlueprintName = "ReadingDateCalculatorTests"
+               ReferencedContainer = "container:FiveGuyes.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/Calendar+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/Calendar+Extension.swift
@@ -29,19 +29,10 @@ extension Calendar {
     }
 }
 
+// MARK: - 수정 주우웅 ❗️❗️❗️❗️❗️
 extension Calendar {
-    /// 두 날짜 사이의 날짜 차이를 계산하고, 값이 없으면 0, 하나라도 값이 있으면 1을 반환
-    func getDateGap(from: Date?, to: Date?) -> Int {
-        if from == nil && to == nil {
-            return 0 // 둘 다 값이 없으면 0
-        } else if let from, let to {
-            let fromDateOnly = from.onlyDate
-            let toDateOnly = to.onlyDate
-            
-            // 두 날짜가 존재하면 차이를 계산
-            return self.dateComponents([.day], from: fromDateOnly, to: toDateOnly).day! + 1
-        } else {
-            return 1 // 하나라도 값이 있으면 1
-        }
+    /// 두 날짜 사이의 날짜 차이 구하기
+    func getDaysBetween(from: Date, to: Date) -> Int {
+        self.dateComponents([.day], from: from, to: to).day ?? 0
     }
 }

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/Date+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/Date+Extension.swift
@@ -84,11 +84,18 @@ extension Date {
     }
 }
 
-
+// MARK: - 수정중 ❗️❗️❗️❗️❗️
 extension Date {
     /// 시간 부분을 버리기
     var onlyDate: Date {
         let component = Calendar.current.dateComponents([.year, .month, .day], from: self)
         return Calendar.current.date(from: component) ?? Date()
+    }
+    
+    /// 날짜에 지정된 일(day)을 추가하거나 감소합니다.
+    /// - Parameter days: 추가하거나 뺄 일수 (음수 값을 전달하면 감소)
+    /// - Returns: 지정된 일수를 더하거나 뺀 새로운 날짜
+    func addingDays(_ days: Int) -> Date {
+        return Calendar.current.date(byAdding: .day, value: days, to: self) ?? Date()
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -115,12 +115,22 @@ struct ReadingScheduleCalculator {
         progress: Progress
     ) {
         // 이미 오늘 읽은 페이지가 기록되었으면 재분배를 수행하지 않음
-        if hasReadPagesAdjustedToday(progress: progress) { return }
+        if hasReadPagesAdjustedToday(progress: progress) {
+            print("페이지 재분배1 ❌❌❌ ")
+            return
+        }
         
-        let targetDate = Date().adjustedDate()
+        let adjustedToday = Date().adjustedDate()
+        
+        // TODO: 독서 시작 날짜와 조정된 오늘 날짜가 같은 날에는 재할당 막기
+        // 불필요한 계산
+        if settings.startDate.toYearMonthDayString() == adjustedToday.toYearMonthDayString() {
+            print("페이지 재분배2 ❌❌❌ ")
+            return
+        }
         
         let remainingReadingDays = getRemainingReadingDays(
-            startDate: targetDate,
+            startDate: adjustedToday,
             targetEndDate: settings.targetEndDate,
             nonReadingDays: settings.nonReadingDays
         )

--- a/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
@@ -92,7 +92,15 @@ final class ReadingProgress: ReadingProgressProtocol {
     }
     
     func findNextReadingPagesPerDay(for settings: Settings) -> Int {
-        let readingScheduleCalculator = ReadingScheduleCalculator()
-        return readingScheduleCalculator.calculatePagesPerDay(settings: settings, progress: self).pagesPerDay
+        let readingPagesCalculator = ReadingPagesCalculator()
+        let readingDateCalculator = ReadingDateCalculator()
+        // TODO: !!!!!!!!!
+        let totalDays = try! readingDateCalculator.calculateValidReadingDays(startDate: Date(), endDate: settings.targetEndDate, excludedDates: settings.nonReadingDays)
+        
+        return readingPagesCalculator.calculatePagesPerDayAndRemainder(
+            totalDays: totalDays,
+            startPage: self.lastPagesRead,
+            endPage: settings.targetEndPage)
+        .pagesPerDay
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Utils/ReadingDateCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Utils/ReadingDateCalculator.swift
@@ -1,0 +1,60 @@
+//
+//  ReadingDateCalculator.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 12/26/24.
+//
+
+import Foundation
+
+struct ReadingDateCalculator {
+    enum DateError: Error {
+        case invalidDateOrder
+    }
+    
+    /// 시작 날짜와 마지막 날짜 사이의 일수 차이를 계산하는 메서드
+    /// - Returns: 두 날짜 사이의 일수 차이 (같은 날일 경우 1을 반환)
+    /// - Throws: `DateError.invalidDateOrder` 시작 날짜가 종료 날짜보다 이후인 경우
+    /// - Note:
+    ///   - 이 메서드에서는 도메인 로직을 통해 시작 날짜와 종료 날짜를 모두 포함하여 결과에 1을 추가합니다.
+    func calculateDaysBetween(startDate: Date, endDate: Date) throws -> Int {
+        // 시작 날짜가 종료 날짜 이후인 경우 에러를 던짐
+        guard startDate <= endDate else {
+            throw DateError.invalidDateOrder
+        }
+
+        // 시작 날짜와 종료 날짜 간의 차이 계산
+        let gap = Calendar.current.getDaysBetween(from: startDate.onlyDate, to: endDate.onlyDate)
+        
+        // 시작 날짜와 종료 날짜를 모두 포함하기 위해 1을 추가
+        return gap + 1
+    }
+    
+    /// 시작 날짜와 마지막 날짜 사이의 유효한 일수를 계산하는 메서드
+    /// - Parameters:
+    ///   - startDate: 시작 날짜
+    ///   - endDate: 마지막 날짜
+    ///   - excludedDates: 제외할 날짜 배열
+    /// - Returns: 유효한 일수 (양쪽 날짜 포함, 제외 날짜는 제외)
+    /// - Throws: `DateError.invalidDateOrder` 시작 날짜가 종료 날짜보다 이후인 경우
+    func calculateValidReadingDays(
+        startDate: Date,
+        endDate: Date,
+        excludedDates: [Date]
+    ) throws -> Int {
+        
+        // 두 날짜 사이의 총 일수를 계산 (양쪽 날짜 포함)
+        let totalDays = try calculateDaysBetween(startDate: startDate, endDate: endDate)
+        
+        // 제외된 날짜 중 시작 날짜와 마지막 날짜 사이에 포함된 날짜 수를 계산
+        let (start, end) = (startDate.onlyDate, endDate.onlyDate)
+        
+        let excludedDaysCount = excludedDates.filter {
+            let excludedDate = $0.onlyDate
+            return excludedDate >= start && excludedDate <= end
+        }.count
+        
+        // 유효한 날짜 수 = 총 일수 - 제외된 날짜 수
+        return totalDays - excludedDaysCount
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Utils/ReadingPagesCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Utils/ReadingPagesCalculator.swift
@@ -1,0 +1,68 @@
+//
+//  ReadingPagesCalculator.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 12/26/24.
+//
+
+import Foundation
+
+struct ReadingPagesCalculator {
+    /// 페이지 계산 중 발생할 수 있는 오류
+    enum CalculationError: Error {
+        case divisionByZero
+    }
+    
+    /// 읽어야 할 페이지의 차이를 계산하는 함수
+    /// - Parameters:
+    ///   - startPage: 시작 페이지
+    ///   - endPage: 종료 페이지
+    /// - Returns: 페이지 차이
+    func calculatePagesBetween(endPage: Int, startPage: Int) -> Int {
+        return endPage - startPage + 1
+    }
+    
+    /// 전체 페이지 수를 전체 일수로 나누어 하루에 할당할 페이지 수를 계산하는 함수
+    /// - Parameters:
+    ///   - totalPages: 전체 남은 페이지 수
+    ///   - totalDays: 전체 남은 일수
+    /// - Returns: 하루에 읽어야 할 페이지 수 (정수 나눗셈 결과)
+    /// - Throws: `CalculationError.divisionByZero` 전체 남은 일수가 0인 경우
+    func calculatePagesPerDay(totalPages: Int, totalDays: Int) throws -> Int {
+        guard totalDays > 0 else {
+            throw CalculationError.divisionByZero
+        }
+        return totalPages / totalDays
+    }
+    
+    /// 전체 페이지 수를 전체 일수로 나누었을 때의 나머지를 계산하는 함수
+    /// - Parameters:
+    ///   - totalPages: 전체 남은 페이지 수
+    ///   - totalDays: 전체 남은 일수
+    /// - Returns: 남은 페이지 수 (나누기 연산의 나머지)
+    /// - Throws: `CalculationError.divisionByZero` 전체 남은 일수가 0인 경우
+    private func calculateRemainderPages(totalPages: Int, totalDays: Int) throws -> Int {
+        guard totalDays > 0 else {
+            throw CalculationError.divisionByZero
+        }
+        return totalPages % totalDays
+    }
+    
+    func calculatePagesPerDayAndRemainder(
+        totalDays: Int,
+        startPage: Int,
+        endPage: Int
+    ) -> (pagesPerDay: Int, remainder: Int) {
+        do {
+            // 총 페이지 수와 하루 할당량 계산
+            let totalPages = calculatePagesBetween(endPage: endPage, startPage: startPage)
+            
+            let pagesPerDay = try calculatePagesPerDay(totalPages: totalPages, totalDays: totalDays)
+            let remainder = try calculateRemainderPages(totalPages: totalPages, totalDays: totalDays)
+            
+            return (pagesPerDay, remainder)
+        } catch {
+            fatalError("calculatePagesPerDayAndRemainder: \(error.localizedDescription)")
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Views/Components/CompletionListView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Components/CompletionListView.swift
@@ -27,7 +27,7 @@ struct CompletionListView: View {
     let completionAlertText = "삭제 후에는 복원할 수 없어요"
     
     var body: some View {
-        var completedBooks = Array(fetchCompletedBooks.reversed())
+        let completedBooks = Array(fetchCompletedBooks.reversed())
         
         VStack(alignment: .leading, spacing: 16) {
             HStack {

--- a/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyPageCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Components/WeeklyPageCalendarView.swift
@@ -278,7 +278,6 @@ struct WeeklyPageCalendarView: View {
     ///   - targetEndDate: 목표 종료 날짜.
     private func calculateLastWeekAndDayIndex(totalWeeks: Int, targetEndDate: Date) {
         lastWeekIndex = totalWeeks - 1
-        
         // 목표 종료 날짜의 요일 인덱스 계산
         lastDayIndex = Calendar.current.getWeekdayIndex(from: targetEndDate)
     }

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookCompletion/CompletionCelebrationView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookCompletion/CompletionCelebrationView.swift
@@ -102,6 +102,7 @@ struct CompletionCelebrationView: View {
     
     private func readingSummary(userSettings: UserSettingsProtocol, readingProgress: any ReadingProgressProtocol) -> some View {
         let readingScheduleCalculator = ReadingScheduleCalculator()
+        let readingPagesCalculator = ReadingPagesCalculator()
         
         // TODO: 완독을 수정할 수도 있기 때문에 완독 날짜가 바뀔 수 있음, 그래서 완독 날짜는 최종에서 업데이트하고 여기서는 오늘 날짜로 보여주기 -> 초기 설정 날보다 빠를 수도 있음 🐯
         let endDateText = Date().toKoreanDateString()
@@ -110,7 +111,9 @@ struct CompletionCelebrationView: View {
         
         // TODO: 위에 이유로 날짜가 바껴서 보이면 아래 로직에 파라미터 값도 바껴야 한다. 🐯
         let totalReadingDays = readingScheduleCalculator.calculateRecordedDays(progress: readingProgress)
-        let pagesPerDay = readingScheduleCalculator.calculateTotalReadingPages(setttings: userSettings) / totalReadingDays
+        let totalReadingPages = readingPagesCalculator.calculatePagesBetween(endPage: userSettings.targetEndPage, startPage: userSettings.startPage)
+        
+        let pagesPerDay = try! readingPagesCalculator.calculatePagesPerDay(totalPages: totalReadingPages, totalDays: totalReadingDays)
         
         return Text("\(startDateText)부터 \(endDateText)까지\n꾸준히 \(pagesPerDay)쪽씩 \(totalReadingDays)일동안 읽었어요 🎉")
             .fontStyle(.caption1)

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/CompletionCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/CompletionCalendarView.swift
@@ -26,15 +26,24 @@ struct CompletionCalendarView: View {
     @State private var isFirstClick = true
     
     private var dayCount: Int {
-        Calendar.current.getDateGap(from: startDate, to: endDate)
+        if let startDate, let endDate {
+            let readingcalculator = ReadingDateCalculator()
+            do {
+                return try readingcalculator.calculateDaysBetween(startDate: startDate, endDate: endDate)
+            } catch {
+                fatalError(error.localizedDescription)
+            }
+        } else {
+            return 1
+        }
     }
     
     private var pagesPerDay: Int {
-        get {
-            if dayCount == 0 {
-                return totalPages
-            }
-            return totalPages / dayCount
+        let readingPagesCalculator = ReadingPagesCalculator()
+        do {
+            return try readingPagesCalculator.calculatePagesPerDay(totalPages: totalPages, totalDays: dayCount)
+        } catch {
+            fatalError(error.localizedDescription)
         }
     }
     

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/FinishGoalView.swift
@@ -183,7 +183,14 @@ struct FinishGoalView: View {
                 let bookData = UserBook(bookMetaData: bookMetaData, userSettings: userSettings, readingProgress: readingProgress, completionStatus: completionStatus)
                 
                 userBook = bookData
-                pagesPerDay = calculator.firstCalculatePagesPerDay(settings: userSettings, progress: readingProgress).pagesPerDay
+                
+                // TODO: !!!!!!!!
+                let totalDays = try! ReadingDateCalculator().calculateValidReadingDays(startDate: userSettings.startDate, endDate: userSettings.targetEndDate, excludedDates: userSettings.nonReadingDays)
+                
+                pagesPerDay = ReadingPagesCalculator().calculatePagesPerDayAndRemainder(
+                    totalDays: totalDays,
+                    startPage: userSettings.startPage,
+                    endPage: userSettings.targetEndPage).pagesPerDay
             }
             .onAppear {
                 // GA4 Tracking

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookSetting/FinishGoalView.swift
@@ -175,7 +175,9 @@ struct FinishGoalView: View {
                 // TODO: 해당 모델 객체를 더 잘 만들 방식 고민하기
                 let bookMetaData = BookMetaData(title: book.title, author: book.author, coverURL: book.cover, totalPages: totalPages)
                 let userSettings = UserSettings(startPage: startPage, targetEndPage: totalPages, startDate: startDate, targetEndDate: endDate, nonReadingDays: bookSettingInputModel.nonReadingDays)
-                let readingProgress = ReadingProgress(lastPagesRead: startPage)
+                
+                // 시작 페이지가 아직 읽지 않은 페이지임을 고려하여 초기 등록 시 -1 처리 추가
+                let readingProgress = ReadingProgress(lastPagesRead: startPage - 1)
                 let completionStatus = CompletionStatus()
   
                 calculator.calculateInitialDailyTargets(for: userSettings, progress: readingProgress)

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/Main/MainHomeView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/Main/MainHomeView.swift
@@ -25,8 +25,6 @@ struct MainHomeView: View {
     private var currentlyReadingBooks: [UserBook]
     
     var body: some View {
-        
-        var currentlyReadingBook = currentlyReadingBooks.first
         let title = currentlyReadingBooks.first?.bookMetaData.title ?? ""
         let mainAlertText = "현재 읽고 있는 <\(title)>\(title.postPositionParticle()) 책장에서 삭제할까요?"
         
@@ -46,7 +44,7 @@ struct MainHomeView: View {
                             .padding(.bottom, 40)
                         Spacer()
                         
-                        if let currentReadingBook = currentlyReadingBooks.first {
+                        if !currentlyReadingBooks.isEmpty {
                             Menu {
                                 Button(role: .destructive) {
                                     showReadingBookAlert = true
@@ -177,18 +175,18 @@ struct MainHomeView: View {
     }
     
     private var titleDescription: some View {
-        let readingScheduleCalculator = ReadingScheduleCalculator()
-        
+        let redingDateCalculator = ReadingDateCalculator()
         return HStack {
             if let currentReadingBook = currentlyReadingBooks.first {
                 let bookMetadata: BookMetaDataProtocol = currentReadingBook.bookMetaData
                 let userSettings: UserSettingsProtocol = currentReadingBook.userSettings
-                let readingProgress: any ReadingProgressProtocol = currentReadingBook.readingProgress
+
+                let remainingReadingDays = try? redingDateCalculator.calculateValidReadingDays(startDate: Date(), endDate: userSettings.targetEndDate, excludedDates: userSettings.nonReadingDays)
                 
                 VStack(alignment: .leading, spacing: 5) {
                     Text("<\(bookMetadata.title)>")
                         .lineLimit(2)
-                    Text("완독까지 \(readingScheduleCalculator.calculateRemainingReadingDays(settings: userSettings, progress: readingProgress))일 남았어요!")
+                    Text("완독까지 \(remainingReadingDays ?? 0)일 남았어요!")
                 }
                 
             } else {

--- a/FiveGuyes/ReadingDateCalculatorTests/ReadingDateCalculatorTests.swift
+++ b/FiveGuyes/ReadingDateCalculatorTests/ReadingDateCalculatorTests.swift
@@ -1,0 +1,107 @@
+//
+//  ReadingDateCalculatorTests.swift
+//  ReadingDateCalculatorTests
+//
+//  Created by zaehorang on 12/26/24.
+//
+
+import Testing
+import Foundation
+
+@testable import FiveGuyes
+
+struct ReadingDateCalculatorTests {
+    let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+    
+    func date(from string: String) -> Date {
+        guard let date = dateFormatter.date(from: string) else {
+            fatalError("Invalid date format: \(string)")
+        }
+        return date
+    }
+    
+    // MARK: - Test calculateDaysBetween
+    @Test
+    func testCalculateDaysBetween_ValidDates() async throws {
+        let startDate = date(from: "2024-12-20 08:00:00")
+        let endDate = date(from: "2024-12-26 22:30:00")
+        
+        let days = try ReadingDateCalculator.calculateDaysBetween(startDate: startDate, endDate: endDate)
+        
+        #expect(days == 7)
+    }
+    
+    @Test
+    func testCalculateDaysBetween_SameDateWithDifferentTimes() async throws {
+        let startDate = date(from: "2024-12-20 00:00:00")
+        let endDate = date(from: "2024-12-20 23:59:59")
+        
+        let days = try ReadingDateCalculator.calculateDaysBetween(startDate: startDate, endDate: endDate)
+        #expect(days == 1)
+    }
+    
+    
+    // MARK: - Test calculateValidDayCount
+    @Test
+    func testCalculateValidDayCount_NoExcludedDatesWithTimes() async throws {
+        let startDate = date(from: "2024-12-20 10:00:00")
+        let endDate = date(from: "2024-12-26 22:00:00")
+        let excludedDates: [Date] = []
+        
+        let validDays = try ReadingDateCalculator.calculateValidReadingDays(
+            startDate: startDate,
+            endDate: endDate,
+            excludedDates: excludedDates
+        )
+        
+        #expect(validDays == 7)
+    }
+    
+    @Test
+    func testCalculateValidDayCount_WithExcludedDatesAndTimes() async throws {
+        let startDate = date(from: "2024-12-20 10:00:00")
+        let endDate = date(from: "2024-12-26 22:00:00")
+        let excludedDates = [
+            date(from: "2024-12-22 08:00:00"),
+            date(from: "2024-12-19 08:00:00"),
+            date(from: "2024-12-24 18:00:00"),
+            date(from: "2024-12-29 18:00:00")
+        ]
+        
+        let validDays = try ReadingDateCalculator.calculateValidReadingDays(
+            startDate: startDate,
+            endDate: endDate,
+            excludedDates: excludedDates
+        )
+        
+        #expect(validDays == 5)
+    }
+    
+    @Test
+    func testCalculateValidDayCount_AllDatesExcludedWithTimes() async throws {
+        let startDate = date(from: "2024-12-20 10:00:00")
+        let endDate = date(from: "2024-12-26 22:00:00")
+        let excludedDates = [
+            date(from: "2024-12-20 11:00:00"),
+            date(from: "2024-12-21 12:00:00"),
+            date(from: "2024-12-22 13:00:00"),
+            date(from: "2024-12-23 14:00:00"),
+            date(from: "2024-12-24 15:00:00"),
+            date(from: "2024-12-25 16:00:00"),
+            date(from: "2024-12-26 17:00:00")
+        ]
+        
+        let validDays = try ReadingDateCalculator.calculateValidReadingDays(
+            startDate: startDate,
+            endDate: endDate,
+            excludedDates: excludedDates
+        )
+        
+        #expect(validDays == 0)
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### **Calculator 구조체 분리**
- Date 및 Page 계산 로직을 각각의 calculator 구조체로 분리하였습니다.
   - **ReadingPagesCalculator**
      - 페이지를 계산하는 로직을 담당하며, 계산을 위해 필요한 값 타입 데이터(totalPages, remainingDays 등)를 파라미터로 받습니다.
      - 이전의 참조 타입 모델을 사용하지 않아 테스트 용이성을 높였습니다.

   - **ReadingDateCalculator**
       - 날짜 관련 계산(예: 남은 날짜 계산, 특정 날짜까지의 진행률 계산)을 담당하며, 필요한 데이터를 값 타입으로 받습니다.
 
   - 두 Calculator 구조체의 메서드 관련 테스트 코드를 추가하여 로직의 신뢰성을 강화했습니다.
 
### 메서드 리팩터링
- ReadingScheduleCalculator 모델에서 반복적으로 사용되던 로직을 별도의 메서드로 분리하였습니다.
- 코드 가독성을 개선하고, 재사용성을 높였으며, 유지보수를 용이하게 했습니다.
