### PR TITLE
[#151] 노티 시간 변경 시 책 정보의 옵셔널 처리 추가

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookProgress/DailyProgressView.swift
@@ -30,7 +30,8 @@ struct DailyProgressView: View {
     @FocusState private var isTextTextFieldFocused: Bool
     
     var body: some View {
-        let userBook = currentlyReadingBooks.first ?? UserBook.dummyUserBookV2
+        // 책이 있을 때만 해당 뷰로 올 수 있기 때문에 우선 강제 언래핑으로 사용
+        let userBook = currentlyReadingBooks.first!
         
         let bookMetadata: BookMetaDataProtocol = userBook.bookMetaData
         let userSettings: UserSettingsProtocol = userBook.userSettings

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/NotiSettingView/NotiSettingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/NotiSettingView/NotiSettingView.swift
@@ -46,7 +46,7 @@ struct NotiSettingView: View {
     }
     
     var body: some View {
-        let userBook = currentlyReadingBooks.first ?? UserBook.dummyUserBookV2
+        let userBook = currentlyReadingBooks.first
         
         ZStack {
             Color.Fills.white // 배경색 지정
@@ -251,8 +251,11 @@ struct NotiSettingView: View {
         isNotificationDisabled = UserDefaultsManager.fetchNotificationDisabled()
     }
     
-    private func handleNotificationStatusChange(isDisabled: Bool, userBook: UserBook) async {
+    private func handleNotificationStatusChange(isDisabled: Bool, userBook: UserBook?) async {
         saveNotificationStatus(isDisabled)
+        
+        // 등록된 책이 없을 때는 노티 설정 X
+        guard let userBook else { return }
         
         if isDisabled {
             await notificationManager.clearRequests()
@@ -261,8 +264,11 @@ struct NotiSettingView: View {
         }
     }
     
-    private func handleNotificationTimeChange(newTime: Date, userBook: UserBook) async {
+    private func handleNotificationTimeChange(newTime: Date, userBook: UserBook?) async {
         saveNotificationTime(newTime)
+        
+        // 등록된 책이 없을 때는 노티 설정 X
+        guard let userBook else { return }
         
         await notificationManager.updateNotification(notificationType: .morning(readingBook: userBook))
     }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 노티 시간 변경 시, 책이 등록되지 않은 경우를 고려해 메서드의 파라미터를 옵셔널 타입으로 수정
- 책 정보가 없을 경우, 노티 변경 메서드 실행을 차단하도록 로직 개선

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/ec117712-09f5-4e75-add6-bcd91a0fd50a" width="300"/>
