### PR TITLE
[#159] 시작 날짜와 마지막 날짜를 시간 없이 비교하도록 수정

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/ReadingScheduleCalculator.swift
@@ -41,6 +41,13 @@ struct ReadingScheduleCalculator {
             targetEndDate: settings.targetEndDate,
             nonReadingDays: settings.nonReadingDays
         )
+        
+        // 목표 종료 페이지와 마지막 날 할당 페이지를 검증 및 수정
+        adjustLastDayTargetPage(
+            progress: progress,
+            targetEndDate: settings.targetEndDate,
+            targetEndPage: settings.targetEndPage
+        )
     }
     
     ///  읽은 페이지 입력 메서드 (오늘 날짜에만 값을 넣을 수 있음)
@@ -110,6 +117,12 @@ struct ReadingScheduleCalculator {
             targetEndDate: settings.targetEndDate,
             nonReadingDays: settings.nonReadingDays
         )
+        // 목표 종료 페이지와 마지막 날 할당 페이지를 검증 및 수정
+        adjustLastDayTargetPage(
+            progress: progress,
+            targetEndDate: settings.targetEndDate,
+            targetEndPage: settings.targetEndPage
+        )
     }
     
     /// 지난 날의 할당량을 읽지 않고, 앱에 새롭게 접속할 때 페이지를 재할당해주는 메서드
@@ -156,14 +169,20 @@ struct ReadingScheduleCalculator {
             targetEndDate: settings.targetEndDate,
             nonReadingDays: settings.nonReadingDays
         )
+        
+        // 목표 종료 페이지와 마지막 날 할당 페이지를 검증 및 수정
+        adjustLastDayTargetPage(
+            progress: progress,
+            targetEndDate: settings.targetEndDate,
+            targetEndPage: settings.targetEndPage
+        )
     }
-    
-
     
     private func getRemainingReadingDays(startDate: Date, targetEndDate: Date, nonReadingDays: [Date]) -> Int {
         do {
             return try readingDateCalculator.calculateValidReadingDays(
                 startDate: startDate,
+                
                 endDate: targetEndDate,
                 excludedDates: nonReadingDays
             )
@@ -294,8 +313,23 @@ extension ReadingScheduleCalculator {
     ) -> Int {
         return progress.readingRecords.values.filter { $0.pagesRead > 0 }.count
     }
+    
+    /// 마지막 날 할당 페이지를 목표 페이지로 재조정하는 메서드
+    /// - Parameters:
+    ///   - progress: 독서 진행 상황 객체
+    ///   - targetEndDate: 목표 종료 날짜
+    ///   - targetEndPage: 목표 종료 페이지
+    private func adjustLastDayTargetPage<Progress: ReadingProgressProtocol>(
+        progress: Progress,
+        targetEndDate: Date,
+        targetEndPage: Int
+    ) {
+        let endDateKey = progress.getReadingRecordsKey(targetEndDate)
+        if progress.readingRecords[endDateKey]?.targetPages != targetEndPage {
+            progress.readingRecords[endDateKey]?.targetPages = targetEndPage
+        }
+    }
 }
-
 
 // MARK: - 독서 날짜가 변경되면 업데이트
 extension ReadingScheduleCalculator {
@@ -345,6 +379,13 @@ extension ReadingScheduleCalculator {
             startDate: adjustedToday,
             targetEndDate: settings.targetEndDate,
             nonReadingDays: settings.nonReadingDays
+        )
+        
+        // 목표 종료 페이지와 마지막 날 할당 페이지를 검증 및 수정
+        adjustLastDayTargetPage(
+            progress: progress,
+            targetEndDate: settings.targetEndDate,
+            targetEndPage: settings.targetEndPage
         )
     }
     

--- a/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Models/UserBook/UserBookModelV2/ReadingProgress.swift
@@ -95,12 +95,18 @@ final class ReadingProgress: ReadingProgressProtocol {
         let readingPagesCalculator = ReadingPagesCalculator()
         let readingDateCalculator = ReadingDateCalculator()
         // TODO: !!!!!!!!!
-        let totalDays = try! readingDateCalculator.calculateValidReadingDays(startDate: Date(), endDate: settings.targetEndDate, excludedDates: settings.nonReadingDays)
-        
-        return readingPagesCalculator.calculatePagesPerDayAndRemainder(
-            totalDays: totalDays,
-            startPage: self.lastPagesRead,
-            endPage: settings.targetEndPage)
-        .pagesPerDay
+        let adjustedToday = Date().adjustedDate()
+        do {
+            let totalDays = try readingDateCalculator.calculateValidReadingDays(startDate: adjustedToday, endDate: settings.targetEndDate, excludedDates: settings.nonReadingDays)
+            
+            return readingPagesCalculator.calculatePagesPerDayAndRemainder(
+                totalDays: totalDays,
+                startPage: self.lastPagesRead,
+                endPage: settings.targetEndPage)
+            .pagesPerDay
+            
+        } catch {
+            return 1
+        }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Utils/ReadingDateCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Utils/ReadingDateCalculator.swift
@@ -19,7 +19,7 @@ struct ReadingDateCalculator {
     ///   - 이 메서드에서는 도메인 로직을 통해 시작 날짜와 종료 날짜를 모두 포함하여 결과에 1을 추가합니다.
     func calculateDaysBetween(startDate: Date, endDate: Date) throws -> Int {
         // 시작 날짜가 종료 날짜 이후인 경우 에러를 던짐
-        guard startDate <= endDate else {
+        guard startDate.onlyDate <= endDate.onlyDate else {
             throw DateError.invalidDateOrder
         }
 

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/BookProgress/DailyProgressView.swift
@@ -25,7 +25,7 @@ struct DailyProgressView: View {
     private let notificationManager = NotificationManager()
     private let readingScheduleCalculator = ReadingScheduleCalculator()
     
-    private let today = Date()
+    private let adjustedToday = Date().adjustedDate()
     
     @FocusState private var isTextTextFieldFocused: Bool
     
@@ -37,7 +37,7 @@ struct DailyProgressView: View {
         let userSettings: UserSettingsProtocol = userBook.userSettings
         let readingProgress: any ReadingProgressProtocol = userBook.readingProgress
         
-        let isTodayCompletionDate = Calendar.current.isDate(today, inSameDayAs: userSettings.targetEndDate)
+        let isTodayCompletionDate = Calendar.current.isDate(adjustedToday, inSameDayAs: userSettings.targetEndDate)
         
         VStack(spacing: 0) {
             HStack {
@@ -75,16 +75,19 @@ struct DailyProgressView: View {
             if isTextTextFieldFocused {
                 Button {
                     if pagesToReadToday > userSettings.targetEndPage {
+                        // 최종 목표보다 더 큰 페이지를 입력하면
                         showAlert = true
                         return
                     } else if isTodayCompletionDate && pagesToReadToday < userSettings.targetEndPage {
+                        // 오늘이 마지막 날인데, 최종 목표를 다 읽지 못하면
                         
+                        // 목표 날짜를 하루 연장 (자동 연장)
                         userSettings.targetEndDate = userSettings.targetEndDate.addDays(1)
                         
                         readingScheduleCalculator.updateReadingProgress(
                             for: userSettings,
                             progress: readingProgress,
-                            pagesRead: pagesToReadToday, from: today
+                            pagesRead: pagesToReadToday, from: adjustedToday
                         )
                         
                         // 노티 세팅하기
@@ -99,7 +102,7 @@ struct DailyProgressView: View {
                             for: userSettings,
                             progress: readingProgress,
                             pagesRead: pagesToReadToday,
-                            from: today
+                            from: adjustedToday
                         )
                         
                         // 노티 세팅하기
@@ -144,7 +147,7 @@ struct DailyProgressView: View {
                     // "확인" 버튼 로직 (최종 타켓 페이지로 수정 및 완독 기록)
                     pagesToReadToday = userSettings.targetEndPage
                     
-                    readingScheduleCalculator.updateReadingProgress(for: userSettings, progress: readingProgress, pagesRead: pagesToReadToday, from: today)
+                    readingScheduleCalculator.updateReadingProgress(for: userSettings, progress: readingProgress, pagesRead: pagesToReadToday, from: adjustedToday)
                     
                     navigationCoordinator.push(.completionCelebration)
                 }
@@ -155,9 +158,8 @@ struct DailyProgressView: View {
         .navigationBarBackButtonHidden(true)
         .customNavigationBackButton()
         .onAppear {
-            print("🐯🐯🐯🐯🐯: \(today)")
             // ⏰
-            if let readingRecord = readingProgress.getAdjustedReadingRecord(for: today) {
+            if let readingRecord = readingProgress.getAdjustedReadingRecord(for: adjustedToday) {
                 pagesToReadToday = readingRecord.targetPages
             }
             


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 시작 날짜와 마지막 날짜를 비교할 때 시간을 제외하고 날짜만 비교하는 로직 추가
   - 페이지를 재분배하면서 시작 날짜와 마지막 날짜가 같아지는 경우가 생김
   - 기존에도 위의 상황을 대비하여 시작 날짜와 마지막 날짜가 같은 경우까지 허용했지만 시간이 다를 수 있다는 것을 고려하지 못함
     <img width="300" alt="image" src="https://github.com/user-attachments/assets/dc19efa4-512d-4d3e-81bf-35b51f0383eb" />
  
- 페이지 재계산 중 시작 날짜와 마지막 날짜가 같아지는 경우, 시간 차이로 인해 발생하는 에러를 방지
- 날짜 비교 로직의 안정성과 일관성을 개선
