### PR TITLE
[#164] 독서 기간 초과 알림 및 연장 기능 추가

### DIFF
--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		24FAF9452CEC5224004FEC3F /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FAF9442CEC5224004FEC3F /* ToastView.swift */; };
 		2613B7522D329FD900AC717F /* WeeklyProgressPagingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2613B7512D329FD900AC717F /* WeeklyProgressPagingSlider.swift */; };
 		2613B7582D34F81E00AC717F /* EmptyImageDefaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2613B7572D34F81E00AC717F /* EmptyImageDefaultView.swift */; };
+		2613B7652D3559D400AC717F /* UnfinishReadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2613B7642D3559D400AC717F /* UnfinishReadingView.swift */; };
 		261714D62CDDDA4000A3241D /* BookSettingsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261714D52CDDDA4000A3241D /* BookSettingsManagerView.swift */; };
 		2622C7D82D2AC4C000AA3FF4 /* DividerLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2622C7D72D2AC4C000AA3FF4 /* DividerLine.swift */; };
 		2622C7DA2D2AC56400AA3FF4 /* CalendarWeekdayHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2622C7D92D2AC56400AA3FF4 /* CalendarWeekdayHeader.swift */; };
@@ -130,6 +131,7 @@
 		24FAF9442CEC5224004FEC3F /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		2613B7512D329FD900AC717F /* WeeklyProgressPagingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyProgressPagingSlider.swift; sourceTree = "<group>"; };
 		2613B7572D34F81E00AC717F /* EmptyImageDefaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyImageDefaultView.swift; sourceTree = "<group>"; };
+		2613B7642D3559D400AC717F /* UnfinishReadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfinishReadingView.swift; sourceTree = "<group>"; };
 		261714D52CDDDA4000A3241D /* BookSettingsManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSettingsManagerView.swift; sourceTree = "<group>"; };
 		2622C7D72D2AC4C000AA3FF4 /* DividerLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerLine.swift; sourceTree = "<group>"; };
 		2622C7D92D2AC56400AA3FF4 /* CalendarWeekdayHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWeekdayHeader.swift; sourceTree = "<group>"; };
@@ -262,6 +264,14 @@
 				26EBDECE2CF4597100B3A2BC /* UserBookModelV1 */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		2613B7612D35592400AC717F /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+				2613B7642D3559D400AC717F /* UnfinishReadingView.swift */,
+			);
+			path = "New Group";
 			sourceTree = "<group>";
 		};
 		2622C8032D2D911200AA3FF4 /* Repository */ = {
@@ -425,6 +435,7 @@
 		26D852FB2CCE40BC0016239A /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				2613B7612D35592400AC717F /* New Group */,
 				26F19A662CD9EF9400F41D6D /* Main */,
 				26410A962D26D0FF00D6B477 /* ReadingCalendar */,
 				1A27D95E2CDA155B00D1E14D /* BookSetting */,
@@ -804,6 +815,7 @@
 				264440502CD8A3AC0031A290 /* CompletionReviewView.swift in Sources */,
 				26EBDEBE2CF2390C00B3A2BC /* CompletionStatusProtocol.swift in Sources */,
 				264440502CD8A3AC0031A290 /* CompletionReviewView.swift in Sources */,
+				2613B7652D3559D400AC717F /* UnfinishReadingView.swift in Sources */,
 				2655532F2CF6D73900288037 /* NotiSettingView.swift in Sources */,
 				26890B952CAE811A008DFF49 /* FiveGuyesApp.swift in Sources */,
 				26CF82582D1D3216005037E4 /* ReadingDateCalculator.swift in Sources */,

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/View+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/View+Extension.swift
@@ -48,4 +48,9 @@ extension View {
             RoundedRectangle(cornerSize: CGSize(width: bottomTrailingRadius, height: topTrailingRadius))
         )
     }
+    
+    /// 네비게이션 드래그 제스처를 비활성화합니다.
+    func disableNavigationGesture() -> some View {
+        self.gesture(DragGesture().onChanged { _ in })
+    }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Stores/NavigationCoordinator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Stores/NavigationCoordinator.swift
@@ -20,6 +20,7 @@ enum Screens: Hashable {
     case completionReview(book: UserBook)
     case completionReviewUpdate(book: UserBook)
     case readingDateEdit(book: UserBook)
+    case unfinishReading(book: UserBook)
 }
 
 @Observable
@@ -50,6 +51,8 @@ final class NavigationCoordinator {
             CompletionReviewView(isUpdateMode: true, userBook: book)
         case .readingDateEdit(book: let book):
             ReadingDateEditView(userBook: book)
+        case .unfinishReading(book: let book):
+            UnfinishReadingView(userBook: book)
         }
     }
 

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/New Group/UnfinishReadingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/New Group/UnfinishReadingView.swift
@@ -1,0 +1,157 @@
+//
+//  UnfinishGoalView.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 1/13/25.
+//
+
+import SwiftUI
+
+struct UnfinishReadingView: View {
+    typealias UserBook = UserBookSchemaV2.UserBookV2
+    
+    @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
+    
+    @Environment(\.modelContext) private var modelContext
+    
+    private var userBook: UserBook
+    
+    // MARK: - init
+    
+    init(userBook: UserBook) {
+        self.userBook = userBook
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            unfinishTitle("목표 기간 종료!")
+                .padding(.bottom, 16)
+            
+            unFinishDescription("총 \(userBook.readingProgress.lastPagesRead) 쪽까지 읽었어요!\n지속적인 노력이 중요하죠")
+                .padding(.bottom, 90)
+                
+            userBookImage(book: userBook)
+                .commonShadow()
+                .padding(.bottom, 28)
+            
+            unfinishMessage("목표 기간을 연장해서\n남은 페이지를 완독할 수 있어요")
+                .padding(.bottom, 80)
+            
+            HStack(spacing: 16) {
+                cancelButton {
+                    markBookAsCompleted()
+                    navigationCoordinator.popToRoot()
+                }
+                
+                readingDateEtidButton {
+                    navigationCoordinator.push(.readingDateEdit(book: userBook))
+                }
+            }
+            .padding(.horizontal, 20)
+            
+            Spacer()
+            
+        }
+        .background(Color.Fills.lightGreen.ignoresSafeArea())
+        .disableNavigationGesture()
+        .customNavigationBackButton {
+            markBookAsCompleted()
+        }
+    }
+    
+    private func unfinishTitle(_ text: String) -> some View {
+        Text(text)
+            .fontStyle(.body, weight: .semibold)
+            .foregroundStyle(.green)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background {
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundStyle(Color.Fills.white)
+            }
+    }
+    
+    private func unFinishDescription(_ text: String) -> some View {
+        Text(text)
+            .fontStyle(.title1, weight: .semibold)
+            .foregroundStyle(Color.Labels.primaryBlack1)
+            .multilineTextAlignment(.center)
+    }
+    
+    private func userBookImage(book: UserBook) -> some View {
+        Group {
+            if let urlString = book.bookMetaData.coverURL {
+                AsyncImage(url: URL(string: urlString)) { image in
+                    image
+                        .resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+            } else {
+                Image("")
+                    .resizable()
+                    .frame(width: 173)
+            }
+        }
+        .scaledToFit()
+        .frame(height: 267)
+        .clipToBookShape()
+    }
+    
+    private func unfinishMessage(_ text: String) -> some View {
+        Text(text)
+            .fontStyle(.caption1)
+            .foregroundStyle(Color.Labels.primaryBlack1)
+            .multilineTextAlignment(.center)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 10)
+            .background {
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundStyle(Color.Fills.white)
+            }
+    }
+    
+    private func readingDateEtidButton(actions: @escaping () -> ()) -> some View {
+        Button(action: actions) {
+            Text("목표 기간 연장하기")
+                .fontStyle(.title2, weight: .semibold)
+                .foregroundStyle(Color.Fills.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+                .background {
+                    RoundedRectangle(cornerRadius: 16)
+                        .foregroundStyle(Color.Colors.green1)
+                }
+        }
+    }
+    
+    private func cancelButton(actions: @escaping () -> ()) -> some View {
+        Button(action: actions) {
+            Text("닫기")
+                .fontStyle(.title2, weight: .semibold)
+                .foregroundStyle(Color.Labels.primaryBlack1)
+                .frame(width: 107, height: 56)
+                .background {
+                    RoundedRectangle(cornerRadius: 16)
+                        .foregroundStyle(Color.Fills.white)
+                }
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func markBookAsCompleted() {
+        userBook.completionStatus.markAsCompleted(review: "")
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving context: \(error)")
+        }
+    }
+}
+
+#Preview {
+    UnfinishReadingView(userBook: UserBookSchemaV2.UserBookV2.dummyUserBookV2)
+}

--- a/FiveGuyes/FiveGuyes/Sources/Views/Screen/ReadingCalendar/ReadingDateEditView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Screen/ReadingCalendar/ReadingDateEditView.swift
@@ -112,7 +112,7 @@ struct ReadingDateEditView: View {
                 // 페이지 재할당 로직 호출
                 reassignPages()
                 // 페이지 나가기
-                navigationCoordinator.pop()
+                navigationCoordinator.popToRoot()
             }
         } label: {
             RoundedRectangle(cornerRadius: 16)

--- a/FiveGuyes/FiveGuyes/Sources/Views/Shared/CustomBackButton.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Views/Shared/CustomBackButton.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 struct CustomBackButton: View {
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+    var action: (() -> Void)? // 추가 액션을 위한 옵셔널 클로저
     
     var body: some View {
         HStack {
             Button {
+                action?() // 액션이 있으면 실행
                 presentationMode.wrappedValue.dismiss()
             } label: {
                 HStack {
@@ -29,16 +31,18 @@ struct CustomBackButton: View {
 }
 
 struct NavigationBackButtonModifier: ViewModifier {
+    var action: (() -> Void)? // 추가 액션
+    
     func body(content: Content) -> some View {
         content
             .navigationBarBackButtonHidden(true)
-            .navigationBarItems(leading: CustomBackButton())
+            .navigationBarItems(leading: CustomBackButton(action: action))
     }
 }
 
 extension View {
-    func customNavigationBackButton() -> some View {
-        self.modifier(NavigationBackButtonModifier())
+    func customNavigationBackButton(action: (() -> Void)? = nil) -> some View {
+        self.modifier(NavigationBackButtonModifier(action: action))
     }
 }
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 목표 기간이 종료된 뒤에 들어오는 경우에 페이지를 입력하면 에러를 발생시키는 로직을 날짜 수정 기능으로 해결합니다.
- 목표 기간이 초과된 경우, 독서 기간 종료 알림을 표시하고, 사용자가 기간을 연장할 수 있는 기능을 추가했습니다.
- 독서 기간이 종료된 책은 `UnfinishReadingView`로 연결되어 관리됩니다.


### 스크린샷 (선택)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1f705b88-0595-464d-a8d4-3ce6aa22f107" />


