### PR TITLE
[#185] WeeklyProgressCalendar SwiftData 의존성 제거

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Domain/Entity/FGUserBook.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Entity/FGUserBook.swift
@@ -49,6 +49,15 @@ struct FGUserSetting: Hashable {
         
         return startDates
     }
+    
+    func remainingReadingDays(today: Date) -> Int {
+        let remainingReadingDays = try? ReadingDateCalculator().calculateValidReadingDays(
+            startDate: Date().adjustedDate(),
+            endDate: targetEndDate,
+            excludedDates: excludedReadingDays)
+        
+        return remainingReadingDays ?? 0
+    }
 }
 
 struct FGReadingProgress: Hashable {
@@ -66,6 +75,8 @@ struct FGReadingProgress: Hashable {
             return dailyReadingRecords[date.toYearMonthDayString()]
         }
     }
+    
+    func getDailyReadingRecord(for date: Date) -> ReadingRecord? { dailyReadingRecords[date.toYearMonthDayString()] }
 }
 
 struct FGCompletionStatus: Hashable {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/WeeklyProgressCalendar.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/WeeklyProgressCalendar.swift
@@ -8,21 +8,20 @@
 import SwiftUI
 
 struct WeeklyProgressCalendar: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
-    let daysOfWeek = ["일", "월", "화", "수", "목", "금", "토"]
-    
-    let today = Date().adjustedDate()
-    
     @State private var allWeekStartDates: [Date] = []
     @State private var currentWeekPageIndex: Int = 0
-    
-    let todayIndex = Calendar.current.getAdjustedWeekdayIndex(from: Date())
     
     @State private var lastWeekIndex = 0
     @State private var lastDayIndex = 0
     
-    var userBook: UserBook
+    let daysOfWeek = ["일", "월", "화", "수", "목", "금", "토"]
+    
+    var userBook: FGUserBook
+    let today: Date
+    
+    private var todayIndex: Int {
+        Calendar.current.getAdjustedWeekdayIndex(from: today)
+    }
     
     var body: some View {
         ScrollViewReader { proxy in
@@ -67,7 +66,7 @@ struct WeeklyProgressCalendar: View {
             .scrollTargetBehavior(.paging)
             .onAppear {
                 // 모든 주 시작 날짜를 가져옴
-                allWeekStartDates = userBook.readingProgress.getAllWeekStartDates(for: userBook.userSettings)
+                allWeekStartDates = userBook.userSettings.weeklyStartDates(today: today)
                 
                 // 오늘 날짜가 포함된 주의 인덱스를 찾음
                 let todayWeekIndex = allWeekStartDates.firstIndex {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/WeeklyReadingProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/WeeklyReadingProgressView.swift
@@ -52,9 +52,12 @@ struct WeeklyReadingProgressView: View {
                 .padding(.top, 22)
                 .padding(.horizontal, 16)
                 
-                WeeklyProgressCalendar(userBook: userBook)
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 18)
+                WeeklyProgressCalendar(
+                    userBook: userBook.toFGUserBook(),
+                    today: adjustedToday
+                )
+                .padding(.horizontal, 16)
+                .padding(.bottom, 18)
             }
             .background {
                 RoundedRectangle(cornerRadius: 16)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- WeeklyProgressCalendar에서 SwiftData 의존성 제거
- 새롭게 선언한 FGUserBook을 활용하여 기존 로직을 동일하게 유지
- 복잡하거나 불필요한 기존 구현은 이번 이슈 범위와 직접적인 관련이 없으므로, 우선 원래 상태를 유지
- 뷰의 최상단에서는 기존처럼 SwiftData 엔터티를 사용하고 있기에, 하위 뷰부터 의존성을 끊어주기 위해 **도메인 엔터티로 변환하는 메서드 toFGUserBook**을 추가하여 사용
