### PR TITLE
[#192] Calendar.app 적용, 주 인덱스 계산/재할당 로직 보완, 캘린더 배경 높이 조정

### DIFF
--- a/FiveGuyes/FiveGuyes/Resources/Extensions/Calendar+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/Calendar+Extension.swift
@@ -8,18 +8,15 @@
 import Foundation
 
 extension Calendar {
-    /// 특정 날짜를 기준으로 -4시간 조정된 요일 인덱스를 반환합니다.
-    /// - Parameters:
-    ///   - date: 기준이 되는 날짜.
-    ///   - hourOffset: 시간 오프셋. 기본값은 -4로 설정되어 있습니다.
-    /// - Returns: 0(일요일)부터 6(토요일)까지의 요일 인덱스.
-    /// - Note: 기본 오프셋(-4)을 사용하여 하루의 기준을 새벽 4시로 설정합니다.
-    func getAdjustedWeekdayIndex(from date: Date, hourOffset: Int = -4) -> Int {
-        // 날짜를 -4시간 조정
-        let adjustedDate = date.adjustedDate(hourOffset: hourOffset)
-        // 요일 계산 (0: 일요일 ~ 6: 토요일)
-        return self.component(.weekday, from: adjustedDate) - 1
-    }
+    static var app: Calendar = {
+        // 한국식 주 규칙으로 고정
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+        calendar.firstWeekday = 1            // 일요일 시작
+        calendar.minimumDaysInFirstWeek = 1  // 하루만 있어도 1주차
+        return calendar
+    }()
     
     /// 주어진 날짜의 요일 인덱스를 반환합니다.
     /// - Parameter date: 기준이 되는 날짜.

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/Calendar+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/Calendar+Extension.swift
@@ -12,7 +12,7 @@ extension Calendar {
         // 한국식 주 규칙으로 고정
         var calendar = Calendar(identifier: .gregorian)
         calendar.locale = Locale(identifier: "ko_KR")
-        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul") ?? .current
         calendar.firstWeekday = 1            // 일요일 시작
         calendar.minimumDaysInFirstWeek = 1  // 하루만 있어도 1주차
         return calendar

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/Date+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/Date+Extension.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Date {
     func startOfMonth() -> Date {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let components = calendar.dateComponents([.year, .month], from: self)
         return calendar.date(from: components)!
     }
@@ -18,7 +18,7 @@ extension Date {
     /// - Parameter days: 추가할 일 수 (음수일 경우 감소)
     /// - Returns: UTC 기준으로 일 수가 추가된 새로운 `Date`
     func addDaysInUTC(_ days: Int) -> Date {
-        var utcCalendar = Calendar.current
+        var utcCalendar = Calendar.app
         utcCalendar.timeZone = TimeZone(secondsFromGMT: 0)! // UTC 시간대 설정
         return utcCalendar.date(byAdding: .day, value: days, to: self) ?? self
     }
@@ -27,7 +27,7 @@ extension Date {
     /// - Parameter days: 추가할 일 수 (음수일 경우 감소)
     /// - Returns: 일 수가 추가된 새로운 `Date`
     func addDays(_ days: Int) -> Date {
-        return Calendar.current.date(byAdding: .day, value: days, to: self) ?? self
+        return Calendar.app.date(byAdding: .day, value: days, to: self) ?? self
     }
     
     /// `yyyy년 MM월 dd일` 형식으로 변환하여 문자열로 반환합니다.
@@ -77,7 +77,7 @@ extension Date {
     
     /// 04:00 AM을 기준으로 날짜를 조정하여 "yyyy-MM-dd" 형식으로 반환
     func toAdjustedYearMonthDayString(hourOffset: Int = -4) -> String {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let adjustedDate = calendar.date(byAdding: .hour, value: hourOffset, to: self) ?? self
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -86,14 +86,14 @@ extension Date {
     
     /// 기준 시각으로 조정된 날짜 반환
     func adjustedDate(hourOffset: Int = -4) -> Date {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         return calendar.date(byAdding: .hour, value: hourOffset, to: self) ?? self
     }
 }
 
 extension Date {
     /// 현재 날짜가 특정 시간 범위에 포함되어 있는지 확인하는 메서드
-    func isInHourRange(start: Int, end: Int, calendar: Calendar = Calendar.current) -> Bool {
+    func isInHourRange(start: Int, end: Int, calendar: Calendar = Calendar.app) -> Bool {
         let hour = calendar.component(.hour, from: self)
         return hour >= start && hour < end
     }
@@ -103,14 +103,14 @@ extension Date {
 extension Date {
     /// 시간 부분을 버리기
     var onlyDate: Date {
-        let component = Calendar.current.dateComponents([.year, .month, .day], from: self)
-        return Calendar.current.date(from: component) ?? Date()
+        let component = Calendar.app.dateComponents([.year, .month, .day], from: self)
+        return Calendar.app.date(from: component) ?? Date()
     }
     
     /// 날짜에 지정된 일(day)을 추가하거나 감소합니다.
     /// - Parameter days: 추가하거나 뺄 일수 (음수 값을 전달하면 감소)
     /// - Returns: 지정된 일수를 더하거나 뺀 새로운 날짜
     func addingDays(_ days: Int) -> Date {
-        return Calendar.current.date(byAdding: .day, value: days, to: self) ?? Date()
+        return Calendar.app.date(byAdding: .day, value: days, to: self) ?? Date()
     }
 }

--- a/FiveGuyes/FiveGuyes/Resources/Extensions/String+Extension.swift
+++ b/FiveGuyes/FiveGuyes/Resources/Extensions/String+Extension.swift
@@ -57,7 +57,7 @@ extension String {
            let dateFormatter = DateFormatter()
            dateFormatter.dateFormat = "yyyy-MM-dd"
            if let date = dateFormatter.date(from: self) {
-               let calendar = Calendar.current
+               let calendar = Calendar.app
                let year = calendar.component(.year, from: date)
                return "\(year)"
            }

--- a/FiveGuyes/FiveGuyes/Sources/Data/SwiftData/Model/UserBookModelV2/ReadingProgress.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Data/SwiftData/Model/UserBookModelV2/ReadingProgress.swift
@@ -37,7 +37,7 @@ final class ReadingProgress: ReadingProgressProtocol {
     
     /// 특정 주의 기록 가져오기
     func getAdjustedWeeklyRecorded(from today: Date) -> [ReadingRecord?] {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let startOfWeek = calendar.dateInterval(of: .weekOfMonth, for: today)?.start ?? today
         
         return (0..<7).map { dayOffset in
@@ -56,7 +56,7 @@ final class ReadingProgress: ReadingProgressProtocol {
         // 오늘이 시작일보다 이전일 경우 처리
         let effectiveStartDay = today < firstDate ? today : firstDate
         
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let firstWeekStart = calendar.dateInterval(of: .weekOfMonth, for: effectiveStartDay)?.start ?? effectiveStartDay
         let lastWeekStart = calendar.dateInterval(of: .weekOfMonth, for: lastDate)?.start ?? lastDate
         

--- a/FiveGuyes/FiveGuyes/Sources/Data/SwiftData/UserBookSchema/UserBookSchemaV2.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Data/SwiftData/UserBookSchema/UserBookSchemaV2.swift
@@ -91,7 +91,7 @@ extension UserBookSchemaV2.UserBookV2 {
             startPage: 1,
             targetEndPage: 300,
             startDate: Date(), // 현재 날짜
-            targetEndDate: Calendar.current.date(byAdding: .day, value: 30, to: Date()) ?? Date(), // 30일 후
+            targetEndDate: Calendar.app.date(byAdding: .day, value: 30, to: Date()) ?? Date(), // 30일 후
             nonReadingDays: []
         ),
         readingProgress: ReadingProgress(

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Entity/Extension/FGUserBook+PreviewDummy.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Entity/Extension/FGUserBook+PreviewDummy.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 // FGUserBook+PreviewDummy.swift
-#if DEBUG
 extension FGUserBook {
     static var dummy: FGUserBook {
         FGUserBook(
@@ -38,4 +37,3 @@ extension FGUserBook {
         )
     }
 }
-#endif

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Entity/FGUserBook.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Entity/FGUserBook.swift
@@ -34,7 +34,7 @@ struct FGUserSetting: Hashable {
         // 오늘이 시작일보다 빠르면 오늘부터 계산 시작
         let effectiveStartDay = today < startDate ? today : startDate
         
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let firstWeekStart = calendar.dateInterval(of: .weekOfMonth, for: effectiveStartDay)?.start ?? effectiveStartDay
         let lastWeekStart = calendar.dateInterval(of: .weekOfMonth, for: targetEndDate)?.start ?? targetEndDate
         
@@ -95,13 +95,17 @@ struct FGReadingProgress: Hashable {
         }
     }
     
-    /// 특정 주의 기록 가져오기
-    func getAdjustedWeeklyRecorded(from today: Date) -> [ReadingRecord?] {
-        let calendar = Calendar.current
+    func weeklyRecords(from today: Date) -> [ReadingRecord?] {
+        let calendar = Calendar.app
+        
+        // 전달된 날짜가 주의 어느 요일이더라도, 해당 주의 "시작일"로 정규화합니다.
+        // 실패 시(이례적)에는 today 자체를 사용합니다.
         let startOfWeek = calendar.dateInterval(of: .weekOfMonth, for: today)?.start ?? today
         
+        // 일요일(0) ~ 토요일(6)까지 7칸을 순회하며, 각 날짜의 기록을 조회합니다.
         return (0..<7).map { dayOffset in
-            let date = calendar.date(byAdding: .day, value: dayOffset, to: startOfWeek)!
+             let date = calendar.date(byAdding: .day, value: dayOffset, to: startOfWeek)!
+            // 내부 저장은 "yyyy-MM-dd" 문자열 키를 사용합니다.
             return dailyReadingRecords[date.toYearMonthDayString()]
         }
     }

--- a/FiveGuyes/FiveGuyes/Sources/Model/NotificationManager.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Model/NotificationManager.swift
@@ -94,7 +94,7 @@ final class NotificationManager {
     }
     
     private func makeDateComponents(date: Date, _ notificationType: NotificationType) -> DateComponents {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let day = calendar.component(.day, from: date)
         let month = calendar.component(.month, from: date)
         let year = calendar.component(.year, from: date)

--- a/FiveGuyes/FiveGuyes/Sources/Model/ReadingScheduleCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Model/ReadingScheduleCalculator.swift
@@ -147,9 +147,8 @@ struct ReadingScheduleCalculator {
             return
         }
         
-        // TODO: 독서 시작 날짜와 조정된 오늘 날짜가 같은 날에는 재할당 막기
-        // 불필요한 계산
-        if settings.startDate.toYearMonthDayString() == adjustedToday.toYearMonthDayString() {
+        // 시작일이 ‘오늘’이거나 ‘미래’인 경우 재할당을 수행하지 않음 (불필요한 계산 방지)
+        if settings.startDate.toYearMonthDayString() >= adjustedToday.toYearMonthDayString() {
             print("페이지 재분배2 ❌❌❌ ")
             return
         }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/Component/TotalCalendarView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/Component/TotalCalendarView.swift
@@ -98,7 +98,7 @@ struct TotalCalendarView: View {
         } else {
             let day = cellIndex - startDayOfWeek + 1
             
-            guard let date = Calendar.current.date(from: DateComponents(
+            guard let date = Calendar.app.date(from: DateComponents(
                 year: getCurrentMonthAndYear().year,
                 month: getCurrentMonthAndYear().month,
                 day: day)
@@ -115,9 +115,9 @@ struct TotalCalendarView: View {
     private func calendarDayContent(date: Date, dateKey: String, currentReadingBook: FGUserBook) -> some View {
         VStack(spacing: 0) {
             if let readingRecord = currentReadingBook.readingProgress.dailyReadingRecords[dateKey] {
-                let isTodayCompletionDate = Calendar.current.isDate(todayDate, inSameDayAs: currentReadingBook.userSettings.targetEndDate)
+                let isTodayCompletionDate = Calendar.app.isDate(todayDate, inSameDayAs: currentReadingBook.userSettings.targetEndDate)
                 
-                if Calendar.current.isDate(date, inSameDayAs: currentReadingBook.userSettings.targetEndDate) {
+                if Calendar.app.isDate(date, inSameDayAs: currentReadingBook.userSettings.targetEndDate) {
                     Image(isTodayCompletionDate ? "completionGreenFlag" : "completionFlag")
                         .resizable()
                         .scaledToFit()
@@ -129,7 +129,7 @@ struct TotalCalendarView: View {
                                 .padding(.bottom, 1)
                                 .padding(.leading, 2)
                         )
-                } else if Calendar.current.isDate(date, inSameDayAs: todayDate) {
+                } else if Calendar.app.isDate(date, inSameDayAs: todayDate) {
                     // 오늘 날짜인 경우 - 초록색 배경에 목표 페이지 수 표시
                     TotalCalendarTextBubble(
                         text: "\(readingRecord.targetPages)",
@@ -172,17 +172,17 @@ struct TotalCalendarView: View {
     // MARK: - Month Navigation
     
     private func previousMonth() {
-        currentMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth) ?? currentMonth
+        currentMonth = Calendar.app.date(byAdding: .month, value: -1, to: currentMonth) ?? currentMonth
     }
     
     private func nextMonth() {
-        currentMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth) ?? currentMonth
+        currentMonth = Calendar.app.date(byAdding: .month, value: 1, to: currentMonth) ?? currentMonth
     }
     
     // MARK: - Get Date
     
     private func getDateFromCalendar() -> (Int, Int) {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let components = calendar.dateComponents([.year, .month], from: currentMonth)
         guard let firstDayOfCurrentMonth = calendar.date(from: components),
               let rangeOfMonth = calendar.range(of: .day, in: .month, for: firstDayOfCurrentMonth) else {
@@ -195,7 +195,7 @@ struct TotalCalendarView: View {
     }
     
     private func getCurrentMonthAndYear() -> (year: Int, month: Int) {
-        let components = Calendar.current.dateComponents([.year, .month], from: currentMonth)
+        let components = Calendar.app.dateComponents([.year, .month], from: currentMonth)
         return (components.year ?? 2024, components.month ?? 1)
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
@@ -33,7 +33,7 @@ struct DailyProgressView: View {
         let userSettings: UserSettingsProtocol = userBook.userSettings
         let readingProgress: any ReadingProgressProtocol = userBook.readingProgress
         
-        let isTodayCompletionDate = Calendar.current.isDate(adjustedToday, inSameDayAs: userSettings.targetEndDate)
+        let isTodayCompletionDate = Calendar.app.isDate(adjustedToday, inSameDayAs: userSettings.targetEndDate)
         
         VStack(spacing: 0) {
             HStack {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
@@ -91,7 +91,6 @@ struct FinishGoalView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             VStack(alignment: .leading, spacing: 0) {
                                 // 책 제목
-                                
                                 Text(book.title)
                                     .fontStyle(.body, weight: .semibold)
                                     .padding(.top, 17)
@@ -179,20 +178,31 @@ struct FinishGoalView: View {
                 // 시작 페이지가 아직 읽지 않은 페이지임을 고려하여 초기 등록 시 -1 처리 추가
                 let readingProgress = ReadingProgress(lastPagesRead: startPage - 1)
                 let completionStatus = CompletionStatus()
-  
+                
                 calculator.calculateInitialDailyTargets(for: userSettings, progress: readingProgress)
                 
-                let bookData = UserBook(bookMetaData: bookMetaData, userSettings: userSettings, readingProgress: readingProgress, completionStatus: completionStatus)
+                let bookData = UserBook(
+                    bookMetaData: bookMetaData,
+                    userSettings: userSettings,
+                    readingProgress: readingProgress,
+                    completionStatus: completionStatus
+                )
                 
                 userBook = bookData
                 
-                // TODO: !!!!!!!!
-                let totalDays = try! ReadingDateCalculator().calculateValidReadingDays(startDate: userSettings.startDate, endDate: userSettings.targetEndDate, excludedDates: userSettings.nonReadingDays)
+                let totalDays = try! ReadingDateCalculator()
+                    .calculateValidReadingDays(
+                        startDate: userSettings.startDate,
+                        endDate: userSettings.targetEndDate,
+                        excludedDates: userSettings.nonReadingDays
+                    )
                 
-                pagesPerDay = ReadingPagesCalculator().calculatePagesPerDayAndRemainder(
-                    totalDays: totalDays,
-                    startPage: userSettings.startPage,
-                    endPage: userSettings.targetEndPage).pagesPerDay
+                pagesPerDay = ReadingPagesCalculator()
+                    .calculatePagesPerDayAndRemainder(
+                        totalDays: totalDays,
+                        startPage: userSettings.startPage,
+                        endPage: userSettings.targetEndPage
+                    ).pagesPerDay
             }
             .onAppear {
                 // GA4 Tracking

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/ReadingBookProgressCell.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/ReadingBookProgressCell.swift
@@ -54,7 +54,7 @@ struct ReadingBookProgressCell: View {
     
     private func backgroundCard() -> some View {
         Rectangle()
-            .frame(height: 202)
+            .frame(height: 210)
             .foregroundStyle(Color.Backgrounds.primary)
             .cornerRadius(16)
     }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
@@ -36,7 +36,7 @@ struct NotiSettingView: View {
     
     // 시간 범위 설정: 04:00 ~ 23:55
     private var timeSelectionRange: ClosedRange<Date> {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let now = Date()
         let startOfDay = calendar.startOfDay(for: now)
         let start = calendar.date(bySettingHour: 4, minute: 0, second: 0, of: startOfDay)!
@@ -223,7 +223,7 @@ struct NotiSettingView: View {
     // MARK: - Method
     // 시간과 분만 저장
     private func saveNotificationTime(_ time: Date) {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let hour = calendar.component(.hour, from: time)
         let minute = calendar.component(.minute, from: time)
         print("Save: \(hour): \(minute)")
@@ -237,7 +237,7 @@ struct NotiSettingView: View {
     
     // 저장된 시간과 분 불러오기
     private func fetchNotificationTime() {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let (hour, minute) = UserDefaultsManager.fetchNotificationReminderTime()
         
         selectedTime =

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/CalendarCellModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/CalendarCellModel.swift
@@ -18,7 +18,7 @@ final class CalendarCellModel: ObservableObject {
     let adjustedToday: Date
     
     /// 날짜 계산에 사용할 캘린더 인스턴스
-    private let calendar = Calendar.current
+    private let calendar = Calendar.app
     
     /// 선택된 범위의 시작 날짜
     private var startDate: Date?
@@ -42,7 +42,7 @@ final class CalendarCellModel: ObservableObject {
     ///   - excludedDates: 제외된 날짜 리스트 (선택 사항)
     ///   - isConfirmed: 선택된 날짜가 확정되었는지 여부
     init(adjustedToday: Date, startDate: Date? = nil, endDate: Date? = nil, excludedDates: [Date] = [], isConfirmed: Bool = false) {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         
         self.adjustedToday = calendar.startOfDay(for: adjustedToday)
         self.startDate = startDate.map { calendar.startOfDay(for: $0) }

--- a/FiveGuyes/FiveGuyes/Sources/Util/CalendarCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Util/CalendarCalculator.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CalendarCalculator {
-    let calendar = Calendar.current
+    let calendar = Calendar.app
     
     /// 주어진 날짜가 속한 월의 첫 번째 날짜를 반환합니다.
     /// - Parameter month: 기준이 되는 날짜.
@@ -55,7 +55,7 @@ struct CalendarCalculator {
     }
     
     func getWeekdayHeaders() -> [String] {
-        let calendar = Calendar.current
+        let calendar = Calendar.app
         let weekdays = calendar.shortStandaloneWeekdaySymbols
         let firstWeekdayIndex = calendar.firstWeekday - 1
         let adjustedWeekdats = Array(weekdays[firstWeekdayIndex...] + weekdays[..<firstWeekdayIndex])

--- a/FiveGuyes/FiveGuyes/Sources/Util/ReadingDateCalculator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Util/ReadingDateCalculator.swift
@@ -24,7 +24,7 @@ struct ReadingDateCalculator {
         }
 
         // 시작 날짜와 종료 날짜 간의 차이 계산
-        let gap = Calendar.current.getDaysBetween(from: startDate.onlyDate, to: endDate.onlyDate)
+        let gap = Calendar.app.getDaysBetween(from: startDate.onlyDate, to: endDate.onlyDate)
         
         // 시작 날짜와 종료 날짜를 모두 포함하기 위해 1을 추가
         return gap + 1


### PR DESCRIPTION
## 문제 상황

- 메인 홈에서 보이는 페이지 정보와 전체 캘린더에서 보이는 페이지 정보가 서로 다른 이슈 발생 (카키)
- 업데이트 후 새로 등록한 책에서도 독서 시작일이 오늘이 아닌 경우 페이지가 잘못 계산되는 문제 발생 (호랑)
  - 독서 시작일을 미래로 설정했음에도 페이지가 오늘 날짜부터 잘못 할당되는 현상
  (참고 이미지는 해당 이슈 참고 부탁드립니다!)

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 전역적으로 사용할 `Calendar.app` 추가  
  (gregorian + Asia/Seoul + 일요일 시작, 첫 주 하루만 있어도 1주차)
- 기존 `Calendar.current` 사용 부분을 `Calendar.app`으로 교체하여 일관된 주 계산 보장
- `todayWeekIndex` 계산 시 `.weekOfMonth` → `.weekOfYear`로 변경하여 월 경계 이슈 해결
- `reassignPagesFromLastReadDate()` 로직 보완  
  - **기존**: 시작일이 오늘인 경우만 재할당 스킵  
  - **변경**: 시작일이 **오늘/미래**인 경우 모두 재할당 스킵 → 잘못된 페이지 분배 방지
- 디자인팀 리뷰 후 캘린더 배경 높이 조정  
  - 예: `ReadingBookProgressCell` 배경 높이 202 → 210
