### PR TITLE
[#194] 알림 설정 화면 백버튼 미표시 문제 수정

### DIFF
--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -1093,7 +1093,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.4;
+				MARKETING_VERSION = 1.5.5;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.FiveNorms.FiveNorms;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1136,7 +1136,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.4;
+				MARKETING_VERSION = 1.5.5;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.FiveNorms.FiveNorms;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/FiveGuyes/FiveGuyes/Sources/Data/SwiftData/Model/UserBookModelV2/BookMetaData.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Data/SwiftData/Model/UserBookModelV2/BookMetaData.swift
@@ -10,10 +10,10 @@ import SwiftData
 
 @Model
 final class BookMetaData: BookMetaDataProtocol {
-    let title: String
-    let author: String
-    let coverURL: String?
-    let totalPages: Int
+    var title: String
+    var author: String
+    var coverURL: String?
+    var totalPages: Int
     
     init(title: String, author: String, coverURL: String?, totalPages: Int) {
         self.title = title

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/Shared/CustomBackButton.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/Shared/CustomBackButton.swift
@@ -12,21 +12,15 @@ struct CustomBackButton: View {
     var action: (() -> Void)? // 추가 액션을 위한 옵셔널 클로저
     
     var body: some View {
-        HStack {
-            Button {
-                action?() // 액션이 있으면 실행
-                presentationMode.wrappedValue.dismiss()
-            } label: {
-                HStack {
-                    Image(systemName: "chevron.left")
-                        .resizable()
-                        .scaledToFit()
-                        .tint(Color.Labels.primaryBlack1)
-                }
-            }
-            Spacer()
+        Button {
+            action?() // 액션이 있으면 실행
+            presentationMode.wrappedValue.dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .resizable()
+                .scaledToFit()
+                .tint(Color.Labels.primaryBlack1)
         }
-        .background(Color.clear)
     }
 }
 
@@ -35,8 +29,13 @@ struct NavigationBackButtonModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    CustomBackButton(action: action)
+                }
+            }
             .navigationBarBackButtonHidden(true)
-            .navigationBarItems(leading: CustomBackButton(action: action))
     }
 }
 
@@ -48,7 +47,7 @@ extension View {
 
 #Preview {
     NavigationStack {
-        EmptyView()
+        Color.red
             .customNavigationBackButton()
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
@@ -152,8 +152,6 @@ struct DailyProgressView: View {
             )
         }
         .navigationTitle("오늘 독서 현황 기록하기")
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
         .customNavigationBackButton()
         .onAppear {
             // ⏰

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
@@ -72,10 +72,8 @@ struct NotiSettingView: View {
         }
         .padding(.horizontal, 20)
         .padding(.top, 10)
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
-        .customNavigationBackButton()
         .navigationTitle("알림 설정")
+        .customNavigationBackButton()
         .task {
             isSystemNotificationEnabled = await notificationManager.requestAuthorization()
         }
@@ -270,9 +268,3 @@ struct NotiSettingView: View {
         await notificationManager.updateNotification(notificationType: .morning(readingBook: userBook))
     }
 }
-
-//#Preview {
-//    NavigationStack {
-//        NotiSettingView()
-//    }
-//}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
@@ -84,8 +84,6 @@ struct ReadingDateEditView: View {
             nextButton()
         }
         .navigationTitle("목표기간 수정하기")
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
         .customNavigationBackButton()
     }
     

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/TotalCalendar/MultiBookProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/TotalCalendar/MultiBookProgressView.swift
@@ -49,8 +49,6 @@ struct MultiBookProgressView: View {
             Spacer()
         }
         .navigationTitle("전체 독서 현황")
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
         .customNavigationBackButton()
         .onAppear {
             // GA4 Tracking


### PR DESCRIPTION
<!--[#이슈번호] Title
ex) [#1] PR Templete 생성
타이틀 양식 참고하고 지우기 !!-->



## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- deprecated된 `navigationBarItems` → `toolbar`로 교체  
- 알림 설정 화면에서 백버튼이 표시되지 않던 문제 해결  
- 기본 `toolbar` 백버튼 스타일(리퀴드 글래스 효과) 유지  
- 전체 네비게이션 바 커스텀은 추후 디자인 리뉴얼 시점에 검토 예정  

Closes #194

### 스크린샷 (선택)
<img src="" width="300"/>

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/c38ec4f5-8c8f-4027-9f4d-a700be164271" />

