### PR TITLE
refactor: 서비스 기반 MVVM 아키텍처 리팩토링 및 문서 최신화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,11 +95,3 @@ iOSInjectionProject/
 *.xcconfig
 
 GoogleService-Info.plist
-
-# For Agents🐯
-.claude
-.codex
-AGENTS.md
-CLAUDE.md
-Docs
-Tasks

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,11 @@ iOSInjectionProject/
 *.xcconfig
 
 GoogleService-Info.plist
+
+# For Agents🐯
+.claude
+.codex
+AGENTS.md
+CLAUDE.md
+Docs
+Tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,24 +5,16 @@ Follow `./PLANS.md`.
 
 # Architecture Docs
 
-When creating or updating `ARCHITECTURE.md`, follow the structure and guidance in:
+When creating or updating architecture documentation, follow:
 - `./docs/references/architecture-doc.md`
-- `./docs/decisions/` (for architecture-level decisions)
+- `./docs/decisions/`
 
 # Git Conventions
 
-For any Git-related action (branching, committing, PR preparation, merging), follow:
+For Git workflow (branching, commit, PR preparation, PR review), follow:
 - `./docs/git/git-convention.md`
-
-If implementation work starts while on `main`, `develop`, or `dev`, create a working branch immediately.
 
 # File Header Convention
 
-For newly added source files, use the repository owner's GitHub nickname in the header:
-
-```swift
-//  Created by zaehorang on <date>.
-```
-
-- Do not use assistant/tool names (e.g., `Codex`) in file headers.
-- If a generated file includes a different creator name, normalize it before commit.
+For source file header rules, follow:
+- `./docs/conventions/file-header-convention.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# ExecPlans
+
+When writing complex features or significant refactors, use an ExecPlan from design to implementation.
+Follow `./PLANS.md`.
+
+# Architecture Docs
+
+When creating or updating `ARCHITECTURE.md`, follow the structure and guidance in:
+- `./docs/references/architecture-doc.md`
+- `./docs/decisions/` (for architecture-level decisions)
+
+# Git Conventions
+
+For any Git-related action (branching, committing, PR preparation, merging), follow:
+- `./docs/git/git-convention.md`
+
+If implementation work starts while on `main`, `develop`, or `dev`, create a working branch immediately.
+
+# File Header Convention
+
+For newly added source files, use the repository owner's GitHub nickname in the header:
+
+```swift
+//  Created by zaehorang on <date>.
+```
+
+- Do not use assistant/tool names (e.g., `Codex`) in file headers.
+- If a generated file includes a different creator name, normalize it before commit.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,146 @@
+# FiveGuyes Architecture
+
+이 문서는 자주 기여하는 개발자와 리뷰어를 위한 **안정적인 아키텍처 지도**입니다.
+
+## 1) Bird's-eye view
+
+FiveGuyes는 사용자의 책/목표일/목표페이지를 입력받아, 매일 읽을 목표와 실제 독서 기록을 관리하는 SwiftUI + SwiftData iOS 앱입니다.
+핵심 동작은 "독서 상태 입력 -> 스케줄 재계산 -> 저장/알림 갱신"의 반복입니다.
+
+입력(ground state):
+- 사용자 책 데이터(메타데이터, 설정, 진행상태, 완독상태)
+- 사용자 액션(책 등록, 오늘 페이지 기록, 목표일 수정, 완독 소감)
+- 알림 설정(UserDefaults + 시스템 권한)
+
+출력(derived state):
+- 일별 누적 목표(`dailyReadingRecords`)
+- 화면별 표시 상태(홈, 캘린더, 완독 화면)
+- 로컬 알림 예약 상태
+
+업데이트 모델:
+- 읽기/설정 변경은 Domain 계산 후 Repository 저장으로 반영됩니다.
+- 화면 상태는 저장 상태를 재조회해서 갱신하는 구조를 기본 원칙으로 합니다.
+
+## 2) Entry points
+
+- 앱 진입점: `FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift`
+- 루트 네비게이션: `FiveGuyes/FiveGuyes/Sources/App/NavigationRootView.swift`
+- 화면 라우팅 정의: `FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NavigationCoordinator.swift`
+- 도메인 퍼사드 서비스: `FiveGuyes/FiveGuyes/Sources/Domain/Service/BookManagementService.swift`
+- 서비스 구현체: `FiveGuyes/FiveGuyes/Sources/Domain/Service/DefaultBookManagementService.swift`
+
+## 3) Code map
+
+`FiveGuyes/FiveGuyes/Sources`의 상위 맵:
+- `App/`: 앱 시작, 루트 네비게이션
+- `Presentation/`: SwiftUI View, UI 상태/네비게이션
+- `Domain/`: 엔티티, 서비스 인터페이스, 비즈니스 규칙
+- `Data/`: Repository 구현, SwiftData 스키마/매핑
+- `Model/`, `Util/`: 레거시 계산기 + V2 계산기/유틸리티
+- `Store/`: 외부 API 연동(도서 검색)
+
+주요 컴포넌트:
+
+### Presentation
+
+- 책임: 사용자 입력 수집, 화면 렌더링, 화면 전환
+- 소유 상태: 포커스/입력값/토글/선택 인덱스 같은 UI 상태
+- 의존: Domain 서비스 프로토콜, Domain 엔티티
+- 금지 의존(목표): SwiftData 모델 타입(`UserBookSchemaV2.UserBookV2`)과 직접 저장 로직
+- 경계 상태: 앱의 최외곽 입력 경계
+
+### Domain
+
+- 책임: 책 등록/기록/완독/삭제, 스케줄 계산, 유효성 규칙
+- 소유 상태: 불변 데이터 구조(`FGUserBook`, `FGUserSetting`, `FGReadingProgress`)
+- 의존: Repository/알림/시간 공급자 같은 추상화
+- 금지 의존: SwiftUI, SwiftData, View 타입
+- 경계 상태: 앱의 핵심 규칙 계층
+
+### Data
+
+- 책임: SwiftData 저장/조회, Domain <-> SwiftData 매핑, 외부 저장소 어댑팅
+- 소유 상태: `UserBookSchemaV2`, `BookMetaData`, `UserSettings`, `ReadingProgress`, `CompletionStatus`
+- 의존: SwiftData 프레임워크
+- 금지 의존: SwiftUI View/네비게이션
+- 경계 상태: 영속성 경계
+
+### Platform/External
+
+- 책임: 알림(`NotificationManager`), 시스템 설정 이동(`SystemSettingsManager`), 외부 API(`APIStore`)
+- 경계 상태: iOS 시스템/네트워크 연동 경계
+
+## 4) Architectural invariants
+
+**Architecture Invariant: Domain 데이터는 `FG*` 타입으로만 계층 경계를 넘는다**
+- Rationale: 저장소 기술(SwiftData) 변경 시 UI/도메인 영향 최소화
+- Enforced by: `BookRepository`, `BookManagementService` 시그니처
+- Violation symptoms: View에서 SwiftData 모델 필드 직접 수정
+
+**Architecture Invariant: SwiftData fetch/save는 Data 계층에서만 수행한다**
+- Rationale: 테스트 가능성과 사이드이펙트 예측 가능성 확보
+- Enforced by: `SwiftDataBookRepository`로 영속성 집중
+- Violation symptoms: View의 `modelContext.insert/save/delete`
+
+**Architecture Invariant: 스케줄 계산 로직은 V2 계산기 단일 경로를 사용한다**
+- Rationale: 중복 계산식 제거 및 결과 일관성 확보
+- Enforced by: `ReadingScheduleCalculatorV2`, `DateMathCalculator`, `PageMathCalculator`
+- Violation symptoms: 화면별 다른 계산 결과, 같은 입력의 상이한 목표 페이지
+
+**Architecture Invariant: 화면은 Command/Query를 서비스 경유로 호출한다**
+- Rationale: Use case 단위 테스트 가능 구조 유지
+- Enforced by: `BookManagementService` API
+- Violation symptoms: View에서 엔티티를 직접 mutate하고 저장 시점이 분산됨
+
+**Architecture Invariant: 변환 로직은 매핑 확장 파일에서만 수행한다**
+- Rationale: 매핑 규칙의 단일 소스 유지
+- Enforced by: `FGUserBook+toUserBookV2.swift`, `UserBookV2+toFGUserBook.swift`
+- Violation symptoms: 임의의 View/Service에서 ad-hoc 변환 코드 생성
+
+**Architecture Invariant: 날짜 경계(자정 유예 포함)는 공용 Date 확장/도우미로 정규화한다**
+- Rationale: 날짜 비교/집계 오차 방지
+- Enforced by: `Date+Extension`, V2 계산기의 date key 처리
+- Violation symptoms: 화면별 날짜 키 불일치, 기록 누락/중복
+
+2026-02-12 기준 1차 리팩터링 범위에서 위 불변식을 만족하도록 경계 이행을 완료했습니다. 후속 개선(추가 ViewModel 분리 등)은 `./docs/execplans/mvvm-architecture-refactoring-execplan.md`에서 추적합니다.
+
+## 5) Boundaries & API surfaces
+
+Boundary A: 도메인 퍼사드 `BookManagementService`
+- 넘어오는 것: 사용자 액션 의도(등록/기록/완독/삭제/조회)
+- 금지되는 것: SwiftData 모델 객체 자체
+
+Boundary B: 영속성 인터페이스 `BookRepository`
+- 넘어오는 것: `FGUserBook`, `FGReadingProgress`, `FGUserSetting` 등 Domain 타입
+- 금지되는 것: ViewModel/SwiftUI 상태 객체
+
+Boundary C: DTO/모델 매핑 확장
+- 파일: `FGUserBook+toUserBookV2.swift`, `UserBookV2+toFGUserBook.swift`
+- 규칙: 모델 변환은 여기서만 수행
+
+Boundary D: 알림/시스템 연동
+- 넘어오는 것: Domain 기반 상태(책 정보, 알림 시간 설정)
+- 금지되는 것: Presentation 계층에서 직접 시스템 권한/요청 생성
+
+"only here" 규칙:
+- SwiftData IO는 `Data/RepositoryImpl`에서만 수행
+- SwiftData <-> Domain 매핑은 `Data/SwiftData/Extensions`, `Domain/Entity/Extension`에서만 수행
+- 외부 API 호출은 `Store/APIStore.swift`(또는 이후 동등 Gateway)에서만 수행
+
+## 6) Cross-cutting concerns
+
+테스트 전략(경계 기준):
+- Pure 계산 테스트: `FiveGuyes/FiveGuyesTests/DateMathCalculatorTests.swift`, `PageMathCalculatorTests.swift`, `ReadingScheduleCalculatorV2Tests.swift`
+- 서비스 테스트: `FiveGuyes/FiveGuyesTests/DefaultBookManagementServiceTests.swift` (Mock Repository 사용)
+- 저장소 테스트: `FiveGuyes/FiveGuyesTests/SwiftDataBookRepositoryTests.swift` (In-memory SwiftData)
+
+에러 처리 전략:
+- Data 계층은 `RepositoryError`로 저장소 실패를 표준화
+- Domain 계산 실패는 `ScheduleCalculationError`로 래핑
+- Presentation은 도메인 에러를 사용자 액션 단위 메시지로 변환
+
+## 7) Related docs
+
+- 리팩터링 실행/결과 기록: `./docs/execplans/mvvm-architecture-refactoring-execplan.md`
+- Presentation 패턴 결정 기록(ADR): `./docs/decisions/adr-0001-presentation-architecture.md`
+- 실행 계획 표준: `./PLANS.md`

--- a/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
@@ -2,7 +2,7 @@
 //  AppDependencies.swift
 //  FiveGuyes
 //
-//  Created by Codex on 2/12/26.
+//  Created by zaehorang on 2/12/26.
 //
 
 import Observation

--- a/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
@@ -1,0 +1,20 @@
+//
+//  AppDependencies.swift
+//  FiveGuyes
+//
+//  Created by Codex on 2/12/26.
+//
+
+import Observation
+import SwiftData
+
+@MainActor
+@Observable
+final class AppDependencies {
+    let bookManagementService: any BookManagementService
+
+    init(modelContainer: ModelContainer) {
+        let repository = SwiftDataBookRepository(modelContainer: modelContainer)
+        self.bookManagementService = DefaultBookManagementService(repository: repository)
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 import FirebaseCore
 
+@MainActor
 @main
 struct FiveGuyesApp: App {
     typealias SDUserBook = UserBookSchemaV2.UserBookV2
@@ -20,10 +21,13 @@ struct FiveGuyesApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     var container: ModelContainer
+    @State private var dependencies: AppDependencies
     
     init() {
         do {
-            self.container = try ModelContainer(for: SDUserBook.self)
+            let modelContainer = try ModelContainer(for: SDUserBook.self)
+            self.container = modelContainer
+            _dependencies = State(initialValue: AppDependencies(modelContainer: modelContainer))
         } catch {
             fatalError("Failed to initialize model container.")
         }
@@ -32,6 +36,7 @@ struct FiveGuyesApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationRootView()
+                .environment(dependencies)
                 .modelContainer(container)
         }
     }

--- a/FiveGuyes/FiveGuyes/Sources/App/NavigationRootView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/NavigationRootView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct NavigationRootView: View {
     @State private var coordinator = NavigationCoordinator()
-    @Environment(\.modelContext) private var modelContext
     
     var body: some View {
         NavigationStack(path: $coordinator.paths) {

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Entity/Extension/FGReadingProgress+Notification.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Entity/Extension/FGReadingProgress+Notification.swift
@@ -1,0 +1,47 @@
+//
+//  FGReadingProgress+Notification.swift
+//  FiveGuyes
+//
+//  Created by Codex on 2/12/26.
+//
+
+import Foundation
+
+extension FGReadingProgress {
+    /// 다음 독서 알림 기준 날짜를 반환합니다.
+    /// lastReadDate 기준 이후(또는 오늘 이후)에서 아직 읽지 않은 첫 날짜를 찾습니다.
+    func findNextReadingDay() -> Date? {
+        let today = lastReadDate ?? Date()
+        let todayString = today.toAdjustedYearMonthDayString()
+
+        for dateString in dailyReadingRecords.keys.sorted() where dateString >= todayString {
+            if dailyReadingRecords[dateString]?.pagesRead == 0 {
+                return dateString.toDate()
+            }
+        }
+        return nil
+    }
+
+    /// 다음 독서일 기준 일일 목표 페이지를 계산합니다.
+    func findNextReadingPagesPerDay(for settings: FGUserSetting) -> Int {
+        let readingPagesCalculator = ReadingPagesCalculator()
+        let readingDateCalculator = ReadingDateCalculator()
+        let adjustedToday = Date().adjustedDate()
+
+        do {
+            let totalDays = try readingDateCalculator.calculateValidReadingDays(
+                startDate: adjustedToday,
+                endDate: settings.targetEndDate,
+                excludedDates: settings.excludedReadingDays
+            )
+
+            return readingPagesCalculator.calculatePagesPerDayAndRemainder(
+                totalDays: totalDays,
+                startPage: self.lastReadPage,
+                endPage: settings.targetEndPage
+            ).pagesPerDay
+        } catch {
+            return 1
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Entity/Extension/FGReadingProgress+Notification.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Entity/Extension/FGReadingProgress+Notification.swift
@@ -2,7 +2,7 @@
 //  FGReadingProgress+Notification.swift
 //  FiveGuyes
 //
-//  Created by Codex on 2/12/26.
+//  Created by zaehorang on 2/12/26.
 //
 
 import Foundation

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Service/BookManagementService.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Service/BookManagementService.swift
@@ -42,6 +42,29 @@ protocol BookManagementService {
     /// - Throws: 완료 처리 실패 시 에러
     func completeBook(id: UUID, completionDate: Date, review: String) async throws
 
+    /// 완독 소감만 수정합니다.
+    /// - Parameters:
+    ///   - id: 대상 책 ID
+    ///   - review: 수정할 소감
+    /// - Throws: 수정 실패 시 에러
+    func updateCompletionReview(id: UUID, review: String) async throws
+
+    /// 목표 기간/휴일 변경을 반영해 스케줄을 재분배합니다.
+    /// - Parameters:
+    ///   - bookId: 대상 책 ID
+    ///   - startDate: 변경된 시작일
+    ///   - targetEndDate: 변경된 종료일
+    ///   - excludedReadingDays: 변경된 쉬는 날 목록
+    ///   - today: 기준 날짜 (보정된 날짜)
+    /// - Throws: 재분배 또는 저장 실패 시 에러
+    func updateReadingPlan(
+        bookId: UUID,
+        startDate: Date,
+        targetEndDate: Date,
+        excludedReadingDays: [Date],
+        today: Date
+    ) async throws
+
     // MARK: - Query (읽기 작업)
 
     /// 읽는 중인 책 목록을 조회합니다.
@@ -59,4 +82,11 @@ protocol BookManagementService {
     /// - Returns: 책 상세 정보
     /// - Throws: 조회 실패 시 에러
     func fetchBookDetail(id: UUID) async throws -> FGUserBook
+
+    /// 앱 재진입 시 오늘 기준으로 남은 독서 스케줄을 재분배합니다.
+    /// - Parameters:
+    ///   - bookId: 대상 책 ID
+    ///   - today: 기준 날짜 (보정된 날짜)
+    /// - Throws: 재분배 실패 또는 목표일 초과 에러
+    func rescheduleOnAppOpen(bookId: UUID, today: Date) async throws
 }

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Service/DefaultBookManagementService.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Service/DefaultBookManagementService.swift
@@ -156,8 +156,13 @@ final class DefaultBookManagementService: BookManagementService {
         // 1. Repository에서 삭제
         try await repository.deleteBook(by: id)
 
-        // 2. 알림 취소 (모든 알림을 제거)
-        await notificationManager.clearRequests()
+        // 2. 남은 읽는 책 기준으로 알림 상태를 재구성
+        let remainingReadingBooks = try await repository.getReadingBooks()
+        if let nextReadingBook = remainingReadingBooks.first {
+            await notificationManager.setupAllNotifications(nextReadingBook)
+        } else {
+            await notificationManager.clearRequests()
+        }
     }
 
     func completeBook(id: UUID, completionDate: Date, review: String) async throws {

--- a/FiveGuyes/FiveGuyes/Sources/Domain/Service/DefaultBookManagementService.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Domain/Service/DefaultBookManagementService.swift
@@ -44,6 +44,30 @@ final class DefaultBookManagementService: BookManagementService {
         return try await repository.fetchBook(by: id)
     }
 
+    func rescheduleOnAppOpen(bookId: UUID, today: Date) async throws {
+        let currentBook = try await repository.fetchBook(by: bookId)
+
+        let updatedProgress = try scheduleCalculator.rescheduleOnAppOpen(
+            settings: currentBook.userSettings,
+            progress: currentBook.readingProgress,
+            today: today
+        )
+
+        guard updatedProgress != currentBook.readingProgress else {
+            return
+        }
+
+        let updatedBook = FGUserBook(
+            id: currentBook.id,
+            bookMetaData: currentBook.bookMetaData,
+            userSettings: currentBook.userSettings,
+            readingProgress: updatedProgress,
+            completionStatus: currentBook.completionStatus
+        )
+
+        try await repository.updateBook(updatedBook)
+    }
+
     // MARK: - Command Operations (향후 구현 예정)
 
     func registerBook(_ input: RegisterBookInput) async throws -> FGUserBook {
@@ -62,9 +86,8 @@ final class DefaultBookManagementService: BookManagementService {
         // 3. Repository에 저장
         try await repository.addBook(bookWithSchedule)
 
-        // 4. 알림 설정 (NotificationManager는 SwiftData 모델 요구)
-        let sdUserBook = bookWithSchedule.toUserBookV2()
-        await notificationManager.setupAllNotifications(sdUserBook)
+        // 4. 알림 설정
+        await notificationManager.setupAllNotifications(bookWithSchedule)
 
         return bookWithSchedule
     }
@@ -119,8 +142,7 @@ final class DefaultBookManagementService: BookManagementService {
         try await repository.updateBook(updatedBook)
 
         // 7. 알림 재설정
-        let sdUserBook = updatedBook.toUserBookV2()
-        await notificationManager.setupAllNotifications(sdUserBook)
+        await notificationManager.setupAllNotifications(updatedBook)
 
         // 8. 완독 여부 확인
         if pagesRead >= currentBook.userSettings.targetEndPage {
@@ -179,6 +201,54 @@ final class DefaultBookManagementService: BookManagementService {
         await notificationManager.clearRequests()
     }
 
+    func updateCompletionReview(id: UUID, review: String) async throws {
+        let currentBook = try await repository.fetchBook(by: id)
+
+        let updatedStatus = FGCompletionStatus(
+            isCompleted: currentBook.completionStatus.isCompleted,
+            reviewAfterCompletion: review
+        )
+
+        try await repository.updateCompletionStatus(bookId: id, status: updatedStatus)
+    }
+
+    func updateReadingPlan(
+        bookId: UUID,
+        startDate: Date,
+        targetEndDate: Date,
+        excludedReadingDays: [Date],
+        today: Date
+    ) async throws {
+        let currentBook = try await repository.fetchBook(by: bookId)
+
+        let newSettings = FGUserSetting(
+            startPage: currentBook.userSettings.startPage,
+            targetEndPage: currentBook.userSettings.targetEndPage,
+            startDate: startDate,
+            targetEndDate: targetEndDate,
+            excludedReadingDays: excludedReadingDays
+        )
+
+        let updatedProgress = try scheduleCalculator.rescheduleForSettingsChange(
+            oldSettings: currentBook.userSettings,
+            newSettings: newSettings,
+            progress: currentBook.readingProgress,
+            today: today
+        )
+
+        let updatedBook = FGUserBook(
+            id: currentBook.id,
+            bookMetaData: currentBook.bookMetaData,
+            userSettings: newSettings,
+            readingProgress: updatedProgress,
+            completionStatus: currentBook.completionStatus
+        )
+
+        try await repository.updateBook(updatedBook)
+
+        await notificationManager.setupAllNotifications(updatedBook)
+    }
+
     // MARK: - Private Helper Methods
 
     /// 목표 날짜 자동 연장 처리
@@ -220,7 +290,6 @@ final class DefaultBookManagementService: BookManagementService {
         try await repository.updateBook(updatedBook)
 
         // 알림 재설정
-        let sdUserBook = updatedBook.toUserBookV2()
-        await notificationManager.setupAllNotifications(sdUserBook)
+        await notificationManager.setupAllNotifications(updatedBook)
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Model/NotificationManager.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Model/NotificationManager.swift
@@ -8,8 +8,6 @@
 import UserNotifications
 
 final class NotificationManager {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     private let notificationCenter = UNUserNotificationCenter.current()
     
     /// 모든 노티를 요청하는 메서드
@@ -20,7 +18,7 @@ final class NotificationManager {
     }
     
     /// 노티를 요청하는 메서드
-    func setupAllNotifications(_ readingBook: UserBook) async {
+    func setupAllNotifications(_ readingBook: FGUserBook) async {
         Task {
             await self.clearRequests()
             

--- a/FiveGuyes/FiveGuyes/Sources/Model/NotificationType.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Model/NotificationType.swift
@@ -8,10 +8,8 @@
 import Foundation
 
 enum NotificationType {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
-    case morning(readingBook: UserBook)
-    case night(readingBook: UserBook)
+    case morning(readingBook: FGUserBook)
+    case night(readingBook: FGUserBook)
     
     func descriptionContent() -> (title: String, body: String) {
         switch self {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionCelebrationView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionCelebrationView.swift
@@ -5,25 +5,22 @@
 //  Created by zaehorang on 11/4/24.
 //
 
-import SwiftData
 import SwiftUI
 // TODO:  완독 날짜 변경은 최종 저장할 때 수정하기
 
 struct CompletionCelebrationView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
     
-    let userBook: UserBook
+    let userBook: FGUserBook
     
     private let celebrationTitleText = "완독 완료!"
     private let celebrationMessageText = "한 권을 전부 읽다니...\n대단한걸요?"
     
     // TODO: 컬러, 폰트 수정하기
     var body: some View {
-        let bookMetadata: BookMetaDataProtocol = userBook.bookMetaData
-        let userSettings: UserSettingsProtocol = userBook.userSettings
-        let readingProgress: any ReadingProgressProtocol = userBook.readingProgress
+        let bookMetadata = userBook.bookMetaData
+        let userSettings = userBook.userSettings
+        let readingProgress = userBook.readingProgress
         
         VStack(spacing: 0) {
             Spacer()
@@ -70,7 +67,7 @@ struct CompletionCelebrationView: View {
             .multilineTextAlignment(.center)
     }
     
-    private func celebrationBookImage(_ bookMetadata: BookMetaDataProtocol) -> some View {
+    private func celebrationBookImage(_ bookMetadata: FGBookMetaData) -> some View {
         let overlayImage = Image("CompletedWandoki")
             .resizable()
             .scaledToFit()
@@ -78,7 +75,7 @@ struct CompletionCelebrationView: View {
             .offset(y: -72)
         
         return Group {
-            if let coverURL = bookMetadata.coverURL, let url = URL(string: coverURL) {
+            if let coverURL = bookMetadata.coverImageURL, let url = URL(string: coverURL) {
                 AsyncImage(url: url) { image in
                     image.resizable()
                 } placeholder: {
@@ -97,8 +94,7 @@ struct CompletionCelebrationView: View {
         }
     }
     
-    private func readingSummary(userSettings: UserSettingsProtocol, readingProgress: any ReadingProgressProtocol) -> some View {
-        let readingScheduleCalculator = ReadingScheduleCalculator()
+    private func readingSummary(userSettings: FGUserSetting, readingProgress: FGReadingProgress) -> some View {
         let readingPagesCalculator = ReadingPagesCalculator()
         
         // TODO: 완독을 수정할 수도 있기 때문에 완독 날짜가 바뀔 수 있음, 그래서 완독 날짜는 최종에서 업데이트하고 여기서는 오늘 날짜로 보여주기 -> 초기 설정 날보다 빠를 수도 있음 🐯
@@ -107,10 +103,14 @@ struct CompletionCelebrationView: View {
         if startDateText > endDateText { startDateText = endDateText }
         
         // TODO: 위에 이유로 날짜가 바껴서 보이면 아래 로직에 파라미터 값도 바껴야 한다. 🐯
-        let totalReadingDays = readingScheduleCalculator.calculateRecordedDays(progress: readingProgress)
+        let totalReadingDays = max(
+            readingProgress.dailyReadingRecords.values.filter { $0.pagesRead > 0 }.count,
+            1
+        )
         let totalReadingPages = readingPagesCalculator.calculatePagesBetween(endPage: userSettings.targetEndPage, startPage: userSettings.startPage)
-        
-        let pagesPerDay = try! readingPagesCalculator.calculatePagesPerDay(totalPages: totalReadingPages, totalDays: totalReadingDays)
+
+        let pagesPerDay = (try? readingPagesCalculator.calculatePagesPerDay(totalPages: totalReadingPages, totalDays: totalReadingDays))
+            ?? totalReadingPages
         
         return Text("\(startDateText)부터 \(endDateText)까지\n꾸준히 \(pagesPerDay)쪽씩 \(totalReadingDays)일동안 읽었어요 🎉")
             .fontStyle(.caption1)

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionReviewView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionReviewView.swift
@@ -5,33 +5,28 @@
 //  Created by zaehorang on 11/4/24.
 //
 
-import SwiftData
 import SwiftUI
 
 struct CompletionReviewView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     private let placeholder: String = "책 속 한 줄이 남긴 여운은 무엇인가요?"
     
     @State private var reflectionText: String = ""
     @State private var showAlert = false
+    @State private var isSubmitting = false
     @FocusState private var isFocusedTextEditor: Bool
     @ObservedObject private var keyboardObserver = KeyboardObserver()
     
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
+    @Environment(AppDependencies.self) private var appDependencies
     
     // 업데이트 상황을 나타내는 불 변수
     var isUpdateMode: Bool = false
         
     // 외부에서 주입받을 수 있는 책 변수
-    var userBook: UserBook
+    let userBook: FGUserBook
     
     var body: some View {
-        let bookMetadata: BookMetaDataProtocol = userBook.bookMetaData
-        var completionStatus: CompletionStatusProtocol = userBook.completionStatus
-        let userSettings = userBook.userSettings
-        
-        let title = bookMetadata.title
+        let title = userBook.bookMetaData.title
         
         ZStack {
             Color.Fills.white.ignoresSafeArea()
@@ -57,25 +52,7 @@ struct CompletionReviewView: View {
                 
                 if keyboardObserver.keyboardIsVisible {
                     Button {
-                        if reflectionText.isEmpty {
-                            showAlert = true
-                        } else {
-                            
-                            if !isUpdateMode {
-                                completionStatus.markAsCompleted(review: reflectionText)
-                                
-                                // TODO: 해당 로직 모델로 옮기기 🐯
-                                userSettings.targetEndDate = Date()
-                                if userSettings.startDate > userSettings.targetEndDate {
-                                    userSettings.startDate = userSettings.targetEndDate
-                                }
-                            } else {
-                                // 업데이트 모드인 경우
-                                completionStatus.completionReview = reflectionText
-                            }
-                            
-                            navigationCoordinator.popToRoot()
-                        }
+                        submitReview()
                     } label: {
                         Text("저장")
                             .frame(maxWidth: .infinity)
@@ -84,6 +61,7 @@ struct CompletionReviewView: View {
                             .foregroundStyle(Color.Fills.white)
                     }
                     .ignoresSafeArea(.keyboard, edges: .bottom)
+                    .disabled(isSubmitting)
                 }
             }
         }
@@ -94,8 +72,48 @@ struct CompletionReviewView: View {
         }
         .customNavigationBackButton()
         .onAppear {
-            reflectionText = completionStatus.completionReview
+            reflectionText = userBook.completionStatus.reviewAfterCompletion
             isFocusedTextEditor = true
+        }
+    }
+
+    @MainActor
+    private func submitReview() {
+        guard !isSubmitting else { return }
+
+        if reflectionText.isEmpty {
+            showAlert = true
+            return
+        }
+
+        isSubmitting = true
+        let review = reflectionText
+
+        Task {
+            do {
+                if isUpdateMode {
+                    try await appDependencies.bookManagementService.updateCompletionReview(
+                        id: userBook.id,
+                        review: review
+                    )
+                } else {
+                    try await appDependencies.bookManagementService.completeBook(
+                        id: userBook.id,
+                        completionDate: Date().adjustedDate(),
+                        review: review
+                    )
+                }
+
+                await MainActor.run {
+                    isSubmitting = false
+                    navigationCoordinator.popToRoot()
+                }
+            } catch {
+                await MainActor.run {
+                    isSubmitting = false
+                }
+                print("완독 소감 저장 중 오류 발생: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
@@ -5,39 +5,35 @@
 //  Created by 신혜연 on 11/5/24.
 //
 
-import SwiftData
 import SwiftUI
 
 struct DailyProgressView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @State private var pagesToReadToday: Int = 0
     @State private var showAlert = false
+    @State private var isSubmitting = false
     
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
+    @Environment(AppDependencies.self) private var appDependencies
     
     private let alertText = "전체쪽수를 초과해서 작성했어요!"
     private let alertMessage = "끝까지 읽은 게 맞나요?"
-    
-    private let notificationManager = NotificationManager()
-    private let readingScheduleCalculator = ReadingScheduleCalculator()
     
     private let adjustedToday = Date().adjustedDate()
     
     @FocusState private var isTextTextFieldFocused: Bool
     
-    let userBook: UserBook
+    let userBook: FGUserBook
     
     var body: some View {
-        let bookMetadata: BookMetaDataProtocol = userBook.bookMetaData
-        let userSettings: UserSettingsProtocol = userBook.userSettings
-        let readingProgress: any ReadingProgressProtocol = userBook.readingProgress
+        let title = userBook.bookMetaData.title
+        let targetEndPage = userBook.userSettings.targetEndPage
+        let targetEndDate = userBook.userSettings.targetEndDate
         
-        let isTodayCompletionDate = Calendar.app.isDate(adjustedToday, inSameDayAs: userSettings.targetEndDate)
+        let isTodayCompletionDate = Calendar.app.isDate(adjustedToday, inSameDayAs: targetEndDate)
         
         VStack(spacing: 0) {
             HStack {
-                Text(isTodayCompletionDate ? "오늘은 <\(bookMetadata.title)>\(bookMetadata.title.postPositionParticle()) 완독하는\n마지막 날이에요"
+                Text(isTodayCompletionDate ? "오늘은 <\(title)>\(title.postPositionParticle()) 완독하는\n마지막 날이에요"
                      : "지금까지 읽은 쪽수를\n알려주세요")
                 .fontStyle(.title2, weight: .semibold)
                 Spacer()
@@ -70,53 +66,13 @@ struct DailyProgressView: View {
             
             if isTextTextFieldFocused {
                 Button {
-                    if pagesToReadToday > userSettings.targetEndPage {
+                    if pagesToReadToday > targetEndPage {
                         // 최종 목표보다 더 큰 페이지를 입력하면
                         showAlert = true
                         return
-                    } else if isTodayCompletionDate && pagesToReadToday < userSettings.targetEndPage {
-                        // 오늘이 마지막 날인데, 최종 목표를 다 읽지 못하면
-                        
-                        // 목표 날짜를 하루 연장 (자동 연장)
-                        userSettings.targetEndDate = userSettings.targetEndDate.addDays(1)
-                        
-                        readingScheduleCalculator.updateReadingProgress(
-                            for: userSettings,
-                            progress: readingProgress,
-                            pagesRead: pagesToReadToday,
-                            from: adjustedToday
-                        )
-                        
-                        // 노티 세팅하기
-                        Task {
-                            await notificationManager.setupAllNotifications(userBook)
-                        }
-                        
-                        navigationCoordinator.popToRoot()
-                    } else {
-                        // 오늘 할당량 기록
-                        readingScheduleCalculator.updateReadingProgress(
-                            for: userSettings,
-                            progress: readingProgress,
-                            pagesRead: pagesToReadToday,
-                            from: adjustedToday
-                        )
-                        
-                        // 노티 세팅하기
-                        Task {
-                            await notificationManager.setupAllNotifications(userBook)
-                        }
-                        
-                        if pagesToReadToday != userSettings.targetEndPage {
-                            navigationCoordinator.popToRoot()
-                        } else {
-                            // 완독한 경우
-                            // TODO: 🐯선택된 책 넣어주기
-                            // TODO:  완독 날짜 변경은 최종 저장할 때 수정하기
-                            navigationCoordinator.push(.completionCelebration(book: userBook))
-                        }
                     }
-                    
+
+                    submitReading()
                 } label: {
                     Text("완료")
                         .frame(maxWidth: .infinity)
@@ -126,6 +82,7 @@ struct DailyProgressView: View {
                     
                 }
                 .ignoresSafeArea(.keyboard, edges: .bottom)
+                .disabled(isSubmitting)
             }
             
         }
@@ -143,11 +100,8 @@ struct DailyProgressView: View {
                 },
                 secondaryButton: .default(Text("확인")) {
                     // "확인" 버튼 로직 (최종 타켓 페이지로 수정 및 완독 기록)
-                    pagesToReadToday = userSettings.targetEndPage
-                    
-                    readingScheduleCalculator.updateReadingProgress(for: userSettings, progress: readingProgress, pagesRead: pagesToReadToday, from: adjustedToday)
-                    // TODO: 🐯선택된 책 넣어주기
-                    navigationCoordinator.push(.completionCelebration(book: userBook))
+                    pagesToReadToday = targetEndPage
+                    submitReading()
                 }
             )
         }
@@ -155,7 +109,7 @@ struct DailyProgressView: View {
         .customNavigationBackButton()
         .onAppear {
             // ⏰
-            if let readingRecord = readingProgress.getAdjustedReadingRecord(for: adjustedToday) {
+            if let readingRecord = userBook.readingProgress.getDailyReadingRecord(for: adjustedToday) {
                 pagesToReadToday = readingRecord.targetPages
             }
             
@@ -164,6 +118,47 @@ struct DailyProgressView: View {
         .onAppear {
             // GA4 Tracking
             Tracking.Screen.dailyProgress.setTracking()
+        }
+    }
+
+    @MainActor
+    private func submitReading() {
+        guard !isSubmitting else { return }
+        isSubmitting = true
+
+        let pagesRead = pagesToReadToday
+        Task {
+            do {
+                let result = try await appDependencies.bookManagementService.recordReading(
+                    bookId: userBook.id,
+                    pagesRead: pagesRead,
+                    readDate: adjustedToday
+                )
+
+                await MainActor.run {
+                    isSubmitting = false
+                    handleRecordResult(result)
+                }
+            } catch {
+                await MainActor.run {
+                    isSubmitting = false
+                }
+                print("독서 기록 저장 중 오류 발생: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
+    private func handleRecordResult(_ result: RecordReadingResult) {
+        switch result {
+        case .recorded:
+            navigationCoordinator.popToRoot()
+        case .dateExtended:
+            navigationCoordinator.popToRoot()
+        case .completed(let updatedBook):
+            navigationCoordinator.push(.completionCelebration(book: updatedBook))
+        case .exceedsTarget:
+            showAlert = true
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
@@ -8,17 +8,14 @@
 import SwiftUI
 
 struct UnfinishReadingView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    
-    @Environment(\.modelContext) private var modelContext
-    
-    private var userBook: UserBook
+    @Environment(AppDependencies.self) private var appDependencies
+
+    private let userBook: FGUserBook
     
     // MARK: - init
     
-    init(userBook: UserBook) {
+    init(userBook: FGUserBook) {
         self.userBook = userBook
     }
     
@@ -29,7 +26,7 @@ struct UnfinishReadingView: View {
             unfinishTitle("목표 기간 종료!")
                 .padding(.bottom, 16)
             
-            unFinishDescription("총 \(userBook.readingProgress.lastPagesRead) 쪽까지 읽었어요!\n지속적인 노력이 중요하죠")
+            unFinishDescription("총 \(userBook.readingProgress.lastReadPage) 쪽까지 읽었어요!\n지속적인 노력이 중요하죠")
                 .padding(.bottom, 90)
                 
             userBookImage(book: userBook)
@@ -41,8 +38,9 @@ struct UnfinishReadingView: View {
             
             HStack(spacing: 16) {
                 cancelButton {
-                    markBookAsCompleted()
-                    navigationCoordinator.popToRoot()
+                    Task {
+                        await completeAndPopToRoot()
+                    }
                 }
                 
                 readingDateEtidButton {
@@ -57,7 +55,7 @@ struct UnfinishReadingView: View {
         .background(Color.Fills.lightGreen.ignoresSafeArea())
         .disableNavigationGesture()
         .customNavigationBackButton {
-            markBookAsCompleted()
+            markBookAsCompletedInBackground()
         }
     }
     
@@ -80,9 +78,9 @@ struct UnfinishReadingView: View {
             .multilineTextAlignment(.center)
     }
     
-    private func userBookImage(book: UserBook) -> some View {
+    private func userBookImage(book: FGUserBook) -> some View {
         Group {
-            if let urlString = book.bookMetaData.coverURL {
+            if let urlString = book.bookMetaData.coverImageURL {
                 AsyncImage(url: URL(string: urlString)) { image in
                     image
                         .resizable()
@@ -142,16 +140,35 @@ struct UnfinishReadingView: View {
     
     // MARK: - Helper Methods
     
-    private func markBookAsCompleted() {
-        userBook.completionStatus.markAsCompleted(review: "")
+    @MainActor
+    private func completeAndPopToRoot() async {
         do {
-            try modelContext.save()
+            try await appDependencies.bookManagementService.completeBook(
+                id: userBook.id,
+                completionDate: userBook.userSettings.targetEndDate,
+                review: ""
+            )
         } catch {
-            print("Error saving context: \(error)")
+            print("미완독 종료 처리 중 오류 발생: \(error.localizedDescription)")
+        }
+        navigationCoordinator.popToRoot()
+    }
+
+    private func markBookAsCompletedInBackground() {
+        Task {
+            do {
+                try await appDependencies.bookManagementService.completeBook(
+                    id: userBook.id,
+                    completionDate: userBook.userSettings.targetEndDate,
+                    review: ""
+                )
+            } catch {
+                print("미완독 종료 처리 중 오류 발생: \(error.localizedDescription)")
+            }
         }
     }
 }
 
 #Preview {
-    UnfinishReadingView(userBook: UserBookSchemaV2.UserBookV2.dummyUserBookV2)
+    UnfinishReadingView(userBook: .dummy)
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
@@ -8,17 +8,12 @@
 import SwiftUI
 
 struct FinishGoalView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
     @Environment(BookSettingInputModel.self) var bookSettingInputModel: BookSettingInputModel
-    @Environment(\.modelContext) private var modelContext
+    @Environment(AppDependencies.self) private var appDependencies
     
     @State private var pagesPerDay: Int = 0
-    @State var userBook: UserBook?
-    
-    private let calculator = ReadingScheduleCalculator()
-    private let notificationManager = NotificationManager()
+    @State private var isSubmitting = false
     
     var body: some View {
         
@@ -140,18 +135,13 @@ struct FinishGoalView: View {
                     Spacer()
                     
                     Button {
-                        // 책 정보 저장하기
-                        if let userBook = userBook {
-                            modelContext.insert(userBook) // SwiftData에 새로운 책 저장
-                            
-                            // 노티 세팅하기
-                            Task {
-                                await notificationManager.setupAllNotifications(userBook)
-                            }
-                            navigationCoordinator.popToRoot()
-                        } else {
-                            print("책 정보 없음")
-                        }
+                        registerBook(
+                            selectedBook: book,
+                            startPage: startPage,
+                            targetEndPage: totalPages,
+                            startDate: startDate,
+                            endDate: endDate
+                        )
                     } label: {
                         HStack {
                             Text("확인")
@@ -165,44 +155,18 @@ struct FinishGoalView: View {
                         .cornerRadius(16)
                         .padding(.horizontal, 16)
                     }
+                    .disabled(isSubmitting)
                     
                 }
                 
             }
             .onAppear {
-                // 1일 할당량 계산
-                // TODO: 해당 모델 객체를 더 잘 만들 방식 고민하기
-                let bookMetaData = BookMetaData(title: book.title, author: book.author, coverURL: book.cover, totalPages: totalPages)
-                let userSettings = UserSettings(startPage: startPage, targetEndPage: totalPages, startDate: startDate, targetEndDate: endDate, nonReadingDays: bookSettingInputModel.nonReadingDays)
-                
-                // 시작 페이지가 아직 읽지 않은 페이지임을 고려하여 초기 등록 시 -1 처리 추가
-                let readingProgress = ReadingProgress(lastPagesRead: startPage - 1)
-                let completionStatus = CompletionStatus()
-                
-                calculator.calculateInitialDailyTargets(for: userSettings, progress: readingProgress)
-                
-                let bookData = UserBook(
-                    bookMetaData: bookMetaData,
-                    userSettings: userSettings,
-                    readingProgress: readingProgress,
-                    completionStatus: completionStatus
+                calculateRecommendedPagesPerDay(
+                    startPage: startPage,
+                    targetEndPage: totalPages,
+                    startDate: startDate,
+                    endDate: endDate
                 )
-                
-                userBook = bookData
-                
-                let totalDays = try! ReadingDateCalculator()
-                    .calculateValidReadingDays(
-                        startDate: userSettings.startDate,
-                        endDate: userSettings.targetEndDate,
-                        excludedDates: userSettings.nonReadingDays
-                    )
-                
-                pagesPerDay = ReadingPagesCalculator()
-                    .calculatePagesPerDayAndRemainder(
-                        totalDays: totalDays,
-                        startPage: userSettings.startPage,
-                        endPage: userSettings.targetEndPage
-                    ).pagesPerDay
             }
             .onAppear {
                 // GA4 Tracking
@@ -210,6 +174,75 @@ struct FinishGoalView: View {
             }
         }
         
+    }
+
+    private func calculateRecommendedPagesPerDay(
+        startPage: Int,
+        targetEndPage: Int,
+        startDate: Date,
+        endDate: Date
+    ) {
+        let excludedDays = bookSettingInputModel.nonReadingDays
+        let totalDays = try? ReadingDateCalculator().calculateValidReadingDays(
+            startDate: startDate,
+            endDate: endDate,
+            excludedDates: excludedDays
+        )
+
+        guard let totalDays, totalDays > 0 else {
+            pagesPerDay = 0
+            return
+        }
+
+        pagesPerDay = ReadingPagesCalculator()
+            .calculatePagesPerDayAndRemainder(
+                totalDays: totalDays,
+                startPage: startPage,
+                endPage: targetEndPage
+            ).pagesPerDay
+    }
+
+    @MainActor
+    private func registerBook(
+        selectedBook: Book,
+        startPage: Int,
+        targetEndPage: Int,
+        startDate: Date,
+        endDate: Date
+    ) {
+        guard !isSubmitting else { return }
+        isSubmitting = true
+
+        let input = RegisterBookInput(
+            bookMetaData: FGBookMetaData(
+                title: selectedBook.title,
+                author: selectedBook.author,
+                coverImageURL: selectedBook.cover,
+                totalPages: targetEndPage
+            ),
+            userSettings: FGUserSetting(
+                startPage: startPage,
+                targetEndPage: targetEndPage,
+                startDate: startDate,
+                targetEndDate: endDate,
+                excludedReadingDays: bookSettingInputModel.nonReadingDays
+            )
+        )
+
+        Task {
+            do {
+                _ = try await appDependencies.bookManagementService.registerBook(input)
+                await MainActor.run {
+                    isSubmitting = false
+                    navigationCoordinator.popToRoot()
+                }
+            } catch {
+                await MainActor.run {
+                    isSubmitting = false
+                }
+                print("책 등록 중 오류 발생: \(error.localizedDescription)")
+            }
+        }
     }
 }
 

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/CompletedBooksView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/CompletedBooksView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct CompletedBooksView: View {
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(AppDependencies.self) private var appDependencies
     
     @State private var selectedBookIndex: Int = 0
     @State var showCompletionAlert: Bool = false
     
     var completedBooks: [FGUserBook]
+    let onDeleteBook: @MainActor (UUID) async -> Bool
     
     let completionAlertMessage = "정말로 내용을 삭제할까요?"
     let completionAlertText = "삭제 후에는 복원할 수 없어요"
@@ -157,12 +157,8 @@ struct CompletedBooksView: View {
 
     @MainActor
     private func deleteCompletedBook(id: UUID, currentCount: Int) async {
-        do {
-            try await appDependencies.bookManagementService.deleteBook(id: id)
-        } catch {
-            print("완독 리스트 삭제 중 오류 발생: \(error.localizedDescription)")
-            return
-        }
+        let deleted = await onDeleteBook(id)
+        guard deleted else { return }
 
         if currentCount <= 1 {
             selectedBookIndex = 0

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/CompletedBooksView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/Components/CompletedBooksView.swift
@@ -5,19 +5,16 @@
 //  Created by zaehorang on 11/5/24.
 //
 
-import SwiftData
 import SwiftUI
 
 struct CompletedBooksView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(\.modelContext) private var modelContext
+    @Environment(AppDependencies.self) private var appDependencies
     
     @State private var selectedBookIndex: Int = 0
     @State var showCompletionAlert: Bool = false
     
-    var completedBooks: [UserBook]
+    var completedBooks: [FGUserBook]
     
     let completionAlertMessage = "정말로 내용을 삭제할까요?"
     let completionAlertText = "삭제 후에는 복원할 수 없어요"
@@ -36,6 +33,8 @@ struct CompletedBooksView: View {
             .padding(.horizontal, 20)
             
             if !completedBooks.isEmpty {
+                let safeSelectedIndex = min(selectedBookIndex, completedBooks.count - 1)
+
                 VStack(alignment: .leading, spacing: 16) {
                     // 가로 스크롤로 completedBooks 보여주기
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -44,7 +43,7 @@ struct CompletedBooksView: View {
                                 let book = completedBooks[index]
                                 
                                 VStack(alignment: .leading, spacing: 6) {
-                                    if let coverURL = book.bookMetaData.coverURL, let url = URL(string: coverURL) {
+                                    if let coverURL = book.bookMetaData.coverImageURL, let url = URL(string: coverURL) {
                                         AsyncImage(url: url) { image in
                                             image
                                                 .resizable()
@@ -83,10 +82,10 @@ struct CompletedBooksView: View {
                     }
                     
                     // 선택된 책의 소감문 및 기타 정보 표시
-                    let selectedBook = completedBooks[selectedBookIndex] 
+                    let selectedBook = completedBooks[safeSelectedIndex]
                     
                     VStack(alignment: .leading, spacing: 10) {
-                        Text(selectedBook.completionStatus.completionReview)
+                        Text(selectedBook.completionStatus.reviewAfterCompletion)
                             .fontStyle(.body)
                             .foregroundStyle(Color.Labels.primaryBlack1)
                             .padding(.bottom, 10)
@@ -97,7 +96,7 @@ struct CompletedBooksView: View {
                             
                             Menu {
                                 Button {
-                                    navigationCoordinator.push(.completionReviewUpdate(book: completedBooks[selectedBookIndex]))
+                                    navigationCoordinator.push(.completionReviewUpdate(book: completedBooks[safeSelectedIndex]))
                                 } label: {
                                     Label("내용 수정하기", systemImage: "pencil")
                                 }
@@ -145,21 +144,30 @@ struct CompletedBooksView: View {
                     .alertFontStyle(.caption1),
                 primaryButton: .cancel(Text("취소하기")),
                 secondaryButton: .destructive(Text("삭제")) {
-                    let book = completedBooks[selectedBookIndex]
-                    
-                    modelContext.delete(book)
-                    
-                    // 처음 셀로 선택하기
-                    selectedBookIndex = 0
-                    
-                    // 데이저 저장이 느려서 직접 저장해주기
-                    do {
-                        try modelContext.save()
-                    } catch {
-                        print(error.localizedDescription)
+                    let safeSelectedIndex = min(selectedBookIndex, completedBooks.count - 1)
+                    let book = completedBooks[safeSelectedIndex]
+
+                    Task {
+                        await deleteCompletedBook(id: book.id, currentCount: completedBooks.count)
                     }
                 }
             )
+        }
+    }
+
+    @MainActor
+    private func deleteCompletedBook(id: UUID, currentCount: Int) async {
+        do {
+            try await appDependencies.bookManagementService.deleteBook(id: id)
+        } catch {
+            print("완독 리스트 삭제 중 오류 발생: \(error.localizedDescription)")
+            return
+        }
+
+        if currentCount <= 1 {
+            selectedBookIndex = 0
+        } else if selectedBookIndex >= currentCount - 1 {
+            selectedBookIndex = currentCount - 2
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift
@@ -125,7 +125,12 @@ struct MainHomeView: View {
                 .padding(.bottom, 40)
                 .padding(.horizontal, 20)
 
-                CompletedBooksView(completedBooks: completedBooks)
+                CompletedBooksView(
+                    completedBooks: completedBooks,
+                    onDeleteBook: { id in
+                        await viewModel.deleteBook(id: id)
+                    }
+                )
             }
             .padding(.top, topSafeAreaInset)
         }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift
@@ -5,86 +5,73 @@
 //  Created by zaehorang on 11/5/24.
 //
 
-import SwiftData
 import SwiftUI
 
 struct MainHomeView: View {
-    typealias SDUserBook = UserBookSchemaV2.UserBookV2
-    
     // Derived UI State
     private enum HomeState {
-        case reading(book: SDUserBook)
+        case reading(book: FGUserBook)
         case hasCompletedNoReading
         case noCompletedNoReading
     }
-    
+
     let notificationManager = NotificationManager()
     let mainAlertMessage = "삭제 후에는 복원할 수 없어요"
     let today = Date().adjustedDate()
-    
+
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(\.modelContext) private var modelContext
-    
+    @Environment(AppDependencies.self) private var appDependencies
+
+    @State private var viewModel = MainHomeViewModel()
     @State private var topSafeAreaInset: CGFloat = 0
     @State private var showReadingBookAlert = false
-    @State private var showCompletionAlert = false
-    
+
     @State private var activeBookID: UUID?
     @State private var selectedBookIndex: Int?
-    
-    @Query(
-        filter: #Predicate<SDUserBook> {
-            $0.completionStatus.isCompleted == false
-        }
-    )
-    private var SDReadingBooks: [SDUserBook]
-    
-    // 완독한 책을 가져오는 쿼리
-    @Query(
-        filter: #Predicate<SDUserBook> { $0.completionStatus.isCompleted == true }
-    )
-    private var SDCompletedBooks: [SDUserBook]
-    
+
     private var readingBooks: [FGUserBook] {
-        SDReadingBooks.map { $0.toFGUserBook() }
+        viewModel.readingBooks
     }
-    
-    private var selectedBook: SDUserBook? {
-        if let selectedBookIndex, !SDReadingBooks.isEmpty && selectedBookIndex < SDReadingBooks.count {
-            return SDReadingBooks[selectedBookIndex]
+
+    private var completedBooks: [FGUserBook] {
+        viewModel.completedBooks
+    }
+
+    private var selectedBook: FGUserBook? {
+        if let selectedBookIndex, !readingBooks.isEmpty && selectedBookIndex < readingBooks.count {
+            return readingBooks[selectedBookIndex]
         }
         return nil
     }
-    
+
     private var homeState: HomeState {
         if let selectedBook {
             return .reading(book: selectedBook)
         }
-        if let firstReading = SDReadingBooks.first {
+        if let firstReading = readingBooks.first {
             return .reading(book: firstReading)
         }
-        return SDCompletedBooks.isEmpty ? .noCompletedNoReading : .hasCompletedNoReading
+        return completedBooks.isEmpty ? .noCompletedNoReading : .hasCompletedNoReading
     }
-    
+
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
                 HStack {
                     Spacer()
                     notiButton {
-                        // 독서 종료일이 제일 가까운 책을 기준으로 노티를 설정합니다.
-                        navigationCoordinator.push(.notiSetting(book: SDReadingBooks.first))
+                        navigationCoordinator.push(.notiSetting(book: readingBooks.first))
                     }
                 }
                 .padding(.bottom, 12)
                 .padding(.trailing, 20)
-                
+
                 HStack(alignment: .center, spacing: 20) {
                     titleView()
-                    
+
                     Spacer()
-                    
-                    if !SDReadingBooks.isEmpty { // 읽고 있는 책이 있는 경우
+
+                    if !readingBooks.isEmpty { // 읽고 있는 책이 있는 경우
                         Menu {
                             ReadingDateEditButton
                             UserBookAddButton
@@ -106,7 +93,9 @@ struct MainHomeView: View {
                                 primaryButton: .cancel(Text("취소하기")),
                                 secondaryButton: .destructive(Text("삭제")) {
                                     if let selectedBookIndex {
-                                        deleteBook(at: selectedBookIndex)
+                                        Task {
+                                            await deleteBook(at: selectedBookIndex)
+                                        }
                                     }
                                 }
                             )
@@ -115,28 +104,28 @@ struct MainHomeView: View {
                 }
                 .padding(.bottom, 8)
                 .padding(.horizontal, 20)
-                
+
                 DotsIndicator(count: readingBooks.count, selectedIndex: $selectedBookIndex)
                     .padding(.bottom, 22)
                     .padding(.horizontal, 20)
-                
+
                 // Home Main Section
                 homeMainSection
                     .padding(.bottom, 12)
                     .shadow(color: .black.opacity(0.04), radius: 2, x: 0, y: 4)
                     .id(navigationCoordinator.getViewReloadTrigger())
                     .onAppear(perform: navigationCoordinator.reloadView)
-                
+
                 HStack(spacing: 16) {
                     calendarFullScreenButton
                         .frame(width: 107)
-                    
+
                     bookActionButton
                 }
                 .padding(.bottom, 40)
                 .padding(.horizontal, 20)
-                
-                CompletedBooksView(completedBooks: SDCompletedBooks)
+
+                CompletedBooksView(completedBooks: completedBooks)
             }
             .padding(.top, topSafeAreaInset)
         }
@@ -149,30 +138,21 @@ struct MainHomeView: View {
         }
         .onChange(of: activeBookID) {
             if let activeBookID {
-                selectedBookIndex = SDReadingBooks.firstIndex(where: { $0.id == activeBookID })
+                selectedBookIndex = readingBooks.firstIndex(where: { $0.id == activeBookID })
             } else {
                 selectedBookIndex = nil
             }
         }
         .onAppear {
             calculateTopSafeAreaInset()
-            reassignReadingSchedules()
         }
         .task {
-            trackScreen()
-            initializeActiveBookID()
-            
-            // 독서 종료일이 제일 가까운 책을 기준으로 노티를 설정합니다.
-            if let currentReadingBook = SDReadingBooks.first {
-                await notificationManager.setupAllNotifications(currentReadingBook)
-            } else {
-                print("노티 설정 실패 ❗️❗️❗️")
-            }
+            await initializeHomeData()
         }
     }
-    
+
     // MARK: - View Property & Function
-    
+
     private var titleText: String {
         switch homeState {
         case .reading(let book):
@@ -183,7 +163,7 @@ struct MainHomeView: View {
             return "완독의 즐거움,\n다음 책에서도 이어나가볼까요?"
         }
     }
-    
+
     private var bookActionText: String {
         switch homeState {
         case .reading:
@@ -194,7 +174,7 @@ struct MainHomeView: View {
             return "완독할 책 추가하기"
         }
     }
-    
+
     private func performBookAction() {
         switch homeState {
         case .reading(let book):
@@ -203,7 +183,7 @@ struct MainHomeView: View {
             navigationCoordinator.push(.bookSettingsManager)
         }
     }
-    
+
     private func titleView() -> some View {
         VStack(alignment: .leading) {
             Text(titleText)
@@ -213,12 +193,12 @@ struct MainHomeView: View {
         .fontStyle(.title1, weight: .semibold)
         .foregroundStyle(Color.Labels.primaryBlack1)
     }
-    
+
     @ViewBuilder
     private var homeMainSection: some View {
         VStack {
             Spacer()
-            
+
             switch homeState {
             case .reading:
                 ReadingBooksCarousel(
@@ -236,7 +216,7 @@ struct MainHomeView: View {
         }
         .frame(height: 275)
     }
-    
+
     private func notiButton(action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: "bell")
@@ -246,14 +226,14 @@ struct MainHomeView: View {
                 .tint(Color.Labels.primaryBlack1)
         }
     }
-    
+
     private var calendarFullScreenButton: some View {
-        let isReadingBookAvailable = !SDReadingBooks.isEmpty
+        let isReadingBookAvailable = !readingBooks.isEmpty
         let backgroundColor = isReadingBookAvailable ? Color.Fills.white : Color.Fills.lightGreen
         let opacity = isReadingBookAvailable ? 1 : 0.2
-        
+
         return Button {
-            if let selectedBook {
+            if isReadingBookAvailable {
                 navigationCoordinator.push(.totalCalendar(books: readingBooks))
             }
         } label: {
@@ -279,7 +259,7 @@ struct MainHomeView: View {
         }
         .disabled(!isReadingBookAvailable)
     }
-    
+
     private var bookActionButton: some View {
         Button {
             performBookAction()
@@ -295,10 +275,9 @@ struct MainHomeView: View {
                 }
         }
     }
-    
+
     private var ReadingDateEditButton: some View {
         Button {
-            // 날짜 수정 화면으로 기기
             if let selectedBook {
                 navigationCoordinator.push(.readingDateEdit(book: selectedBook))
             }
@@ -307,7 +286,7 @@ struct MainHomeView: View {
                 .foregroundStyle(Color.Labels.primaryBlack1)
         }
     }
-    
+
     private var UserBookAddButton: some View {
         Button {
             navigationCoordinator.push(.bookSettingsManager)
@@ -316,7 +295,7 @@ struct MainHomeView: View {
                 .foregroundStyle(Color.Labels.primaryBlack1)
         }
     }
-    
+
     private var DeleteReadingBookButton: some View {
         Button(role: .destructive) {
             showReadingBookAlert = true
@@ -324,9 +303,9 @@ struct MainHomeView: View {
             Label("삭제", systemImage: "trash")
         }
     }
-    
+
     // MARK: - Helper Method
-    private func getMainAlertText(book: SDUserBook?) -> String {
+    private func getMainAlertText(book: FGUserBook?) -> String {
         if let book {
             let title = book.bookMetaData.title
             return "현재 읽고 있는 <\(title)>\(title.postPositionParticle()) 책장에서 삭제할까요?"
@@ -334,46 +313,31 @@ struct MainHomeView: View {
             return ""
         }
     }
-    
-    private func getRemainingDays(book: SDUserBook) -> Int {
-        let redingDateCalculator = ReadingDateCalculator()
-        let remainingReadingDays = try? redingDateCalculator.calculateValidReadingDays(
-            startDate: Date().adjustedDate(),
-            endDate: book.userSettings.targetEndDate,
-            excludedDates: book.userSettings.nonReadingDays)
-        
-        return remainingReadingDays ?? 0
-    }
-    
-    private func deleteBook(at index: Int) {
-        guard index < SDReadingBooks.count else { return }
-        
-        let bookToDelete = SDReadingBooks[index]
-        modelContext.delete(bookToDelete)
-        
-        // 데이터 저장
-        do {
-            try modelContext.save()
-        } catch {
-            print("데이터 저장 중 오류 발생: \(error.localizedDescription)")
-        }
-        
+
+    @MainActor
+    private func deleteBook(at index: Int) async {
+        guard index < readingBooks.count else { return }
+
+        let bookToDelete = readingBooks[index]
+        let deleted = await viewModel.deleteBook(id: bookToDelete.id)
+        guard deleted else { return }
+
         // 삭제 후 인덱스 업데이트
-        if SDReadingBooks.isEmpty {
+        if readingBooks.isEmpty {
             selectedBookIndex = nil
-        } else if index >= SDReadingBooks.count {
-            selectedBookIndex = SDReadingBooks.count - 1
+        } else if index >= readingBooks.count {
+            selectedBookIndex = readingBooks.count - 1
         }
     }
-    
+
     private func trackScreen() {
-        if SDReadingBooks.isEmpty {
+        if readingBooks.isEmpty {
             Tracking.Screen.homeBeforeBookSetting.setTracking()
         } else {
             Tracking.Screen.homeAfterBookSetting.setTracking()
         }
     }
-    
+
     private func calculateTopSafeAreaInset() {
         if let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
@@ -381,37 +345,38 @@ struct MainHomeView: View {
             topSafeAreaInset = window.safeAreaInsets.top
         }
     }
-    
-    private func reassignReadingSchedules() {
-        guard !SDReadingBooks.isEmpty else { return }
-        
-        let readingScheduleCalculator = ReadingScheduleCalculator()
-        
-        for book in SDReadingBooks {
-            do {
-                try readingScheduleCalculator
-                    .reassignPagesFromLastReadDate(
-                        settings: book.userSettings,
-                        progress: book.readingProgress
-                    )
-            } catch ReadingScheduleError.targetDatePassed {
-                // 종료 날짜 초과 에러가 발생한 경우 날짜 연장 뷰로 이동
-                navigationCoordinator.push(.unfinishReading(book: book))
-                continue
-            } catch {
-                print("예상치 못한 에러 발생: \(error.localizedDescription)")
-            }
-        }
-        
-        // 데이터 저장
-        do {
-            try modelContext.save()
-        } catch {
-            print("읽기 스케줄 저장 중 오류 발생: \(error.localizedDescription)")
+
+    @MainActor
+    private func reassignReadingSchedules() async {
+        let overdueBooks = await viewModel.rescheduleOnAppOpen(today: today)
+        guard !overdueBooks.isEmpty else { return }
+
+        for book in overdueBooks {
+            navigationCoordinator.push(.unfinishReading(book: book))
         }
     }
-    
+
+    @MainActor
+    private func setupNotificationsForCurrentBook() async {
+        // 독서 종료일이 제일 가까운 책을 기준으로 노티를 설정합니다.
+        if let currentReadingBook = readingBooks.first {
+            await notificationManager.setupAllNotifications(currentReadingBook)
+        } else {
+            print("노티 설정 실패 ❗️❗️❗️")
+        }
+    }
+
     private func initializeActiveBookID() {
-        activeBookID = SDReadingBooks.first?.id
+        activeBookID = readingBooks.first?.id
+    }
+
+    @MainActor
+    private func initializeHomeData() async {
+        viewModel.configure(bookManagementService: appDependencies.bookManagementService)
+        await viewModel.loadBooks()
+        await reassignReadingSchedules()
+        trackScreen()
+        initializeActiveBookID()
+        await setupNotificationsForCurrentBook()
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
@@ -5,12 +5,9 @@
 //  Created by zaehorang on 11/27/24.
 //
 
-import SwiftData
 import SwiftUI
 
 struct NotiSettingView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @Environment(\.scenePhase) private var scenePhase // 앱 상태 감지
     
     @State private var selectedTime: Date = Date() // 데이트 피커에 사용될 시간
@@ -22,7 +19,7 @@ struct NotiSettingView: View {
     @State private var notificationStatusTask: Task<Void, Never>?
     @State private var notificationTimeTask: Task<Void, Never>?
     
-    let userBook: UserBook?
+    let userBook: FGUserBook?
     
     private let notificationManager = NotificationManager()
     
@@ -246,7 +243,7 @@ struct NotiSettingView: View {
         isNotificationDisabled = UserDefaultsManager.fetchNotificationDisabled()
     }
     
-    private func handleNotificationStatusChange(isDisabled: Bool, userBook: UserBook?) async {
+    private func handleNotificationStatusChange(isDisabled: Bool, userBook: FGUserBook?) async {
         saveNotificationStatus(isDisabled)
         
         // 등록된 책이 없을 때는 노티 설정 X
@@ -259,7 +256,7 @@ struct NotiSettingView: View {
         }
     }
     
-    private func handleNotificationTimeChange(newTime: Date, userBook: UserBook?) async {
+    private func handleNotificationTimeChange(newTime: Date, userBook: FGUserBook?) async {
         saveNotificationTime(newTime)
         
         // 등록된 책이 없을 때는 노티 설정 X

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct ReadingDateEditView: View {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
-    
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
+    @Environment(AppDependencies.self) private var appDependencies
     
-    private let userBook: UserBook
+    private let userBook: FGUserBook
     
     @StateObject private var calendarCellModel: CalendarCellModel
+    @State private var isSubmitting = false
     
     private var adjustedToday: Date
     private let calendarCalculator = CalendarCalculator()
@@ -49,7 +49,7 @@ struct ReadingDateEditView: View {
         }
     }
     
-    init(userBook: UserBook) {
+    init(userBook: FGUserBook) {
         self.adjustedToday = Date().adjustedDate()
         self.userBook = userBook
         
@@ -59,7 +59,7 @@ struct ReadingDateEditView: View {
             adjustedToday: adjustedToday,
             startDate: userSettings.startDate,
             endDate: userSettings.targetEndDate,
-            excludedDates: userSettings.nonReadingDays,
+            excludedDates: userSettings.excludedReadingDays,
             isConfirmed: false)
         
         self._calendarCellModel = StateObject(wrappedValue: calendarCellModel)
@@ -107,10 +107,7 @@ struct ReadingDateEditView: View {
                     calendarCellModel.confirmDates()
                 }
             } else {
-                // 페이지 재할당 로직 호출
-                reassignPages()
-                // 페이지 나가기
-                navigationCoordinator.popToRoot()
+                submitReadingPlanUpdate()
             }
         } label: {
             RoundedRectangle(cornerRadius: 16)
@@ -127,7 +124,7 @@ struct ReadingDateEditView: View {
         .padding(.top, 14)
         .padding(.bottom, 21)
         .padding(.horizontal, 16)
-        .disabled(!calendarCellModel.isRangeComplete())
+        .disabled(!calendarCellModel.isRangeComplete() || isSubmitting)
     }
     
     private func goalSelectionText() -> some View {
@@ -157,26 +154,42 @@ struct ReadingDateEditView: View {
         }
     }
     
-    private func reassignPages() {
-        let userSetting = userBook.userSettings
-        guard let startDate = calendarCellModel.getStartDate(), let endDate = calendarCellModel.getEndDate() else { return }
-        
-        userSetting.startDate = startDate
-        userSetting.targetEndDate = endDate
-        userSetting.nonReadingDays = calendarCellModel.getExcludedDates()
-        
-        let readingScheduleCalculator = ReadingScheduleCalculator()
-        
-        readingScheduleCalculator.reassignPagesForUpdatedDates(
-            settings: userSetting,
-            progress: userBook.readingProgress
-        )
-    }
-    
     private func restDaySelectionText() -> some View {
         HStack(alignment: .top) {
             Text("쉬는 날을 다시 설정할 수 있어요!\n건너뛰어도 괜찮아요")
             Spacer()
+        }
+    }
+
+    @MainActor
+    private func submitReadingPlanUpdate() {
+        guard !isSubmitting else { return }
+        guard let startDate = calendarCellModel.getStartDate(),
+              let endDate = calendarCellModel.getEndDate() else { return }
+
+        isSubmitting = true
+        let excludedDays = calendarCellModel.getExcludedDates()
+
+        Task {
+            do {
+                try await appDependencies.bookManagementService.updateReadingPlan(
+                    bookId: userBook.id,
+                    startDate: startDate,
+                    targetEndDate: endDate,
+                    excludedReadingDays: excludedDays,
+                    today: adjustedToday
+                )
+
+                await MainActor.run {
+                    isSubmitting = false
+                    navigationCoordinator.popToRoot()
+                }
+            } catch {
+                await MainActor.run {
+                    isSubmitting = false
+                }
+                print("목표기간 수정 저장 중 오류 발생: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
@@ -1,0 +1,75 @@
+//
+//  MainHomeViewModel.swift
+//  FiveGuyes
+//
+//  Created by Codex on 2/13/26.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class MainHomeViewModel {
+    private(set) var readingBooks: [FGUserBook] = []
+    private(set) var completedBooks: [FGUserBook] = []
+
+    private var bookManagementService: (any BookManagementService)?
+
+    func configure(bookManagementService: any BookManagementService) {
+        guard self.bookManagementService == nil else { return }
+        self.bookManagementService = bookManagementService
+    }
+
+    func loadBooks() async {
+        guard let bookManagementService else { return }
+
+        do {
+            async let readingResult = bookManagementService.fetchReadingBooks()
+            async let completedResult = bookManagementService.fetchCompletedBooks()
+            let (readingBooks, completedBooks) = try await (readingResult, completedResult)
+
+            self.readingBooks = readingBooks
+            self.completedBooks = completedBooks
+        } catch {
+            print("홈 목록 조회 중 오류 발생: \(error.localizedDescription)")
+        }
+    }
+
+    func deleteBook(id: UUID) async -> Bool {
+        guard let bookManagementService else { return false }
+
+        do {
+            try await bookManagementService.deleteBook(id: id)
+            await loadBooks()
+            return true
+        } catch {
+            print("데이터 삭제 중 오류 발생: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    func rescheduleOnAppOpen(today: Date) async -> [FGUserBook] {
+        guard let bookManagementService else { return [] }
+        guard !readingBooks.isEmpty else { return [] }
+
+        let currentBooks = readingBooks
+        var overdueBooks: [FGUserBook] = []
+
+        for book in currentBooks {
+            do {
+                try await bookManagementService.rescheduleOnAppOpen(
+                    bookId: book.id,
+                    today: today
+                )
+            } catch ScheduleCalculationError.targetDatePassed {
+                overdueBooks.append(book)
+            } catch {
+                print("페이지 재분배 중 오류 발생: \(error.localizedDescription)")
+            }
+        }
+
+        await loadBooks()
+        return overdueBooks
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
@@ -25,9 +25,8 @@ final class MainHomeViewModel {
         guard let bookManagementService else { return }
 
         do {
-            async let readingResult = bookManagementService.fetchReadingBooks()
-            async let completedResult = bookManagementService.fetchCompletedBooks()
-            let (readingBooks, completedBooks) = try await (readingResult, completedResult)
+            let readingBooks = try await bookManagementService.fetchReadingBooks()
+            let completedBooks = try await bookManagementService.fetchCompletedBooks()
 
             self.readingBooks = readingBooks
             self.completedBooks = completedBooks

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
@@ -2,7 +2,7 @@
 //  MainHomeViewModel.swift
 //  FiveGuyes
 //
-//  Created by Codex on 2/13/26.
+//  Created by zaehorang on 2/13/26.
 //
 
 import Foundation

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NavigationCoordinator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NavigationCoordinator.swift
@@ -9,18 +9,17 @@ import SwiftUI
 
 // TODO: 추가되는 뷰 추가하기
 enum Screens: Hashable {
-    typealias UserBook = UserBookSchemaV2.UserBookV2
     case empty
     case mainHome
-    case notiSetting(book: UserBook?)
+    case notiSetting(book: FGUserBook?)
     case bookSettingsManager
     case totalCalendar(books: [FGUserBook])
-    case dailyProgress(book: UserBook)
-    case completionCelebration(book: UserBook)
-    case completionReview(book: UserBook)
-    case completionReviewUpdate(book: UserBook)
-    case readingDateEdit(book: UserBook)
-    case unfinishReading(book: UserBook)
+    case dailyProgress(book: FGUserBook)
+    case completionCelebration(book: FGUserBook)
+    case completionReview(book: FGUserBook)
+    case completionReviewUpdate(book: FGUserBook)
+    case readingDateEdit(book: FGUserBook)
+    case unfinishReading(book: FGUserBook)
 }
 
 @Observable

--- a/FiveGuyes/FiveGuyesTests/DefaultBookManagementServiceTests.swift
+++ b/FiveGuyes/FiveGuyesTests/DefaultBookManagementServiceTests.swift
@@ -438,4 +438,60 @@ struct DefaultBookManagementServiceTests {
         #expect(updatedBook.userSettings.startDate == earlyCompletionDate)
         #expect(updatedBook.userSettings.targetEndDate == earlyCompletionDate)
     }
+
+    @Test("updateCompletionReview로 완독 소감만 수정")
+    func testUpdateCompletionReview() async throws {
+        let mockRepository = MockBookRepository()
+        let service = DefaultBookManagementService(repository: mockRepository)
+
+        var testBook = createTestBook(totalPages: 300, isCompleted: true)
+        testBook.completionStatus = FGCompletionStatus(
+            isCompleted: true,
+            reviewAfterCompletion: "기존 소감"
+        )
+        await mockRepository.setBooks([testBook])
+
+        try await service.updateCompletionReview(id: testBook.id, review: "수정된 소감")
+
+        let updatedBook = try await mockRepository.fetchBook(by: testBook.id)
+        #expect(updatedBook.completionStatus.isCompleted == true)
+        #expect(updatedBook.completionStatus.reviewAfterCompletion == "수정된 소감")
+        #expect(updatedBook.userSettings.targetEndDate == testBook.userSettings.targetEndDate)
+    }
+
+    @Test("updateReadingPlan으로 목표기간/쉬는날 변경 시 설정과 진행률이 갱신됨")
+    func testUpdateReadingPlan() async throws {
+        let mockRepository = MockBookRepository()
+        let service = DefaultBookManagementService(repository: mockRepository)
+
+        var testBook = createTestBook(totalPages: 300, isCompleted: false)
+        testBook.readingProgress = FGReadingProgress(
+            dailyReadingRecords: [
+                makeDate("2025-01-01").toYearMonthDayString(): ReadingRecord(targetPages: 10, pagesRead: 10),
+                makeDate("2025-01-02").toYearMonthDayString(): ReadingRecord(targetPages: 20, pagesRead: 20),
+            ],
+            lastReadDate: makeDate("2025-01-02"),
+            lastReadPage: 20
+        )
+        await mockRepository.setBooks([testBook])
+
+        let newStartDate = makeDate("2025-01-01")
+        let newEndDate = makeDate("2025-02-10")
+        let excludedDays = [makeDate("2025-01-05")]
+        let today = makeDate("2025-01-03")
+
+        try await service.updateReadingPlan(
+            bookId: testBook.id,
+            startDate: newStartDate,
+            targetEndDate: newEndDate,
+            excludedReadingDays: excludedDays,
+            today: today
+        )
+
+        let updatedBook = try await mockRepository.fetchBook(by: testBook.id)
+        #expect(updatedBook.userSettings.startDate == newStartDate)
+        #expect(updatedBook.userSettings.targetEndDate == newEndDate)
+        #expect(updatedBook.userSettings.excludedReadingDays == excludedDays)
+        #expect(updatedBook.readingProgress != testBook.readingProgress)
+    }
 }

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,150 @@
+# Codex Execution Plans (ExecPlans):
+
+This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
+
+## How to use ExecPlans and PLANS.md
+
+When authoring an executable specification (ExecPlan), follow PLANS.md _to the letter_. If it is not in your context, refresh your memory by reading the entire PLANS.md file. Be thorough in reading (and re-reading) source material to produce an accurate specification. When creating a spec, start from the skeleton and flesh it out as you do your research.
+
+When implementing an executable specification (ExecPlan), do not prompt the user for "next steps"; simply proceed to the next milestone. Keep all sections up to date, add or split entries in the list at every stopping point to affirmatively state the progress made and next steps. Resolve ambiguities autonomously, and commit frequently.
+
+When discussing an executable specification (ExecPlan), record decisions in a log in the spec for posterity; it should be unambiguously clear why any change to the specification was made. ExecPlans are living documents, and it should always be possible to restart from _only_ the ExecPlan and no other work.
+
+When researching a design with challenging requirements or significant unknowns, use milestones to implement proof of concepts, "toy implementations", etc., that allow validating whether the user's proposal is feasible. Read the source code of libraries by finding or acquiring them, research deeply, and include prototypes to guide a fuller implementation.
+
+## Requirements
+
+NON-NEGOTIABLE REQUIREMENTS:
+
+* Every ExecPlan must be fully self-contained. Self-contained means that in its current form it contains all knowledge and instructions needed for a novice to succeed.
+* Every ExecPlan is a living document. Contributors are required to revise it as progress is made, as discoveries occur, and as design decisions are finalized. Each revision must remain fully self-contained.
+* Every ExecPlan must enable a complete novice to implement the feature end-to-end without prior knowledge of this repo.
+* Every ExecPlan must produce a demonstrably working behavior, not merely code changes to "meet a definition".
+* Every ExecPlan must define every term of art in plain language or do not use it.
+
+Purpose and intent come first. Begin by explaining, in a few sentences, why the work matters from a user's perspective: what someone can do after this change that they could not do before, and how to see it working. Then guide the reader through the exact steps to achieve that outcome, including what to edit, what to run, and what they should observe.
+
+The agent executing your plan can list files, read files, search, run the project, and run tests. It does not know any prior context and cannot infer what you meant from earlier milestones. Repeat any assumption you rely on. Do not point to external blogs or docs; if knowledge is required, embed it in the plan itself in your own words. If an ExecPlan builds upon a prior ExecPlan and that file is checked in, incorporate it by reference. If it is not, you must include all relevant context from that plan.
+
+## Formatting
+
+Format and envelope are simple and strict. Each ExecPlan must be one single fenced code block labeled as `md` that begins and ends with triple backticks. Do not nest additional triple-backtick code fences inside; when you need to show commands, transcripts, diffs, or code, present them as indented blocks within that single fence. Use indentation for clarity rather than code fences inside an ExecPlan to avoid prematurely closing the ExecPlan's code fence. Use two newlines after every heading, use # and ## and so on, and correct syntax for ordered and unordered lists.
+
+When writing an ExecPlan to a Markdown (.md) file where the content of the file *is only* the single ExecPlan, you should omit the triple backticks.
+
+Write in plain prose. Prefer sentences over lists. Avoid checklists, tables, and long enumerations unless brevity would obscure meaning. Checklists are permitted only in the `Progress` section, where they are mandatory. Narrative sections must remain prose-first.
+
+## Guidelines
+
+Self-containment and plain language are paramount. If you introduce a phrase that is not ordinary English ("daemon", "middleware", "RPC gateway", "filter graph"), define it immediately and remind the reader how it manifests in this repository (for example, by naming the files or commands where it appears). Do not say "as defined previously" or "according to the architecture doc." Include the needed explanation here, even if you repeat yourself.
+
+Avoid common failure modes. Do not rely on undefined jargon. Do not describe "the letter of a feature" so narrowly that the resulting code compiles but does nothing meaningful. Do not outsource key decisions to the reader. When ambiguity exists, resolve it in the plan itself and explain why you chose that path. Err on the side of over-explaining user-visible effects and under-specifying incidental implementation details.
+
+Anchor the plan with observable outcomes. State what the user can do after implementation, the commands to run, and the outputs they should see. Acceptance should be phrased as behavior a human can verify ("after starting the server, navigating to [http://localhost:8080/health](http://localhost:8080/health) returns HTTP 200 with body OK") rather than internal attributes ("added a HealthCheck struct"). If a change is internal, explain how its impact can still be demonstrated (for example, by running tests that fail before and pass after, and by showing a scenario that uses the new behavior).
+
+Specify repository context explicitly. Name files with full repository-relative paths, name functions and modules precisely, and describe where new files should be created. If touching multiple areas, include a short orientation paragraph that explains how those parts fit together so a novice can navigate confidently. When running commands, show the working directory and exact command line. When outcomes depend on environment, state the assumptions and provide alternatives when reasonable.
+
+Be idempotent and safe. Write the steps so they can be run multiple times without causing damage or drift. If a step can fail halfway, include how to retry or adapt. If a migration or destructive operation is necessary, spell out backups or safe fallbacks. Prefer additive, testable changes that can be validated as you go.
+
+Validation is not optional. Include instructions to run tests, to start the system if applicable, and to observe it doing something useful. Describe comprehensive testing for any new features or capabilities. Include expected outputs and error messages so a novice can tell success from failure. Where possible, show how to prove that the change is effective beyond compilation (for example, through a small end-to-end scenario, a CLI invocation, or an HTTP request/response transcript). State the exact test commands appropriate to the project’s toolchain and how to interpret their results.
+
+Capture evidence. When your steps produce terminal output, short diffs, or logs, include them inside the single fenced block as indented examples. Keep them concise and focused on what proves success. If you need to include a patch, prefer file-scoped diffs or small excerpts that a reader can recreate by following your instructions rather than pasting large blobs.
+
+## Milestones
+
+Milestones are narrative, not bureaucracy. If you break the work into milestones, introduce each with a brief paragraph that describes the scope, what will exist at the end of the milestone that did not exist before, the commands to run, and the acceptance you expect to observe. Keep it readable as a story: goal, work, result, proof. Progress and milestones are distinct: milestones tell the story, progress tracks granular work. Both must exist. Never abbreviate a milestone merely for the sake of brevity, do not leave out details that could be crucial to a future implementation.
+
+Each milestone must be independently verifiable and incrementally implement the overall goal of the execution plan.
+
+## Living plans and design decisions
+
+* ExecPlans are living documents. As you make key design decisions, update the plan to record both the decision and the thinking behind it. Record all decisions in the `Decision Log` section.
+* ExecPlans must contain and maintain a `Progress` section, a `Surprises & Discoveries` section, a `Decision Log`, and an `Outcomes & Retrospective` section. These are not optional.
+* When you discover optimizer behavior, performance tradeoffs, unexpected bugs, or inverse/unapply semantics that shaped your approach, capture those observations in the `Surprises & Discoveries` section with short evidence snippets (test output is ideal).
+* If you change course mid-implementation, document why in the `Decision Log` and reflect the implications in `Progress`. Plans are guides for the next contributor as much as checklists for you.
+* At completion of a major task or the full plan, write an `Outcomes & Retrospective` entry summarizing what was achieved, what remains, and lessons learned.
+
+# Prototyping milestones and parallel implementations
+
+It is acceptable—-and often encouraged—-to include explicit prototyping milestones when they de-risk a larger change. Examples: adding a low-level operator to a dependency to validate feasibility, or exploring two composition orders while measuring optimizer effects. Keep prototypes additive and testable. Clearly label the scope as “prototyping”; describe how to run and observe results; and state the criteria for promoting or discarding the prototype.
+
+Prefer additive code changes followed by subtractions that keep tests passing. Parallel implementations (e.g., keeping an adapter alongside an older path during migration) are fine when they reduce risk or enable tests to continue passing during a large migration. Describe how to validate both paths and how to retire one safely with tests. When working with multiple new libraries or feature areas, consider creating spikes that evaluate the feasibility of these features _independently_ of one another, proving that the external library performs as expected and implements the features we need in isolation.
+
+## Skeleton of a Good ExecPlan
+
+    # <Short, action-oriented description>
+
+    This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+    If PLANS.md file is checked into the repo, reference the path to that file here from the repository root and note that this document must be maintained in accordance with PLANS.md.
+
+    ## Purpose / Big Picture
+
+    Explain in a few sentences what someone gains after this change and how they can see it working. State the user-visible behavior you will enable.
+
+    ## Progress
+
+    Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if it requires splitting a partially completed task into two (“done” vs. “remaining”). This section must always reflect the actual current state of the work.
+
+    - [x] (2025-10-01 13:00Z) Example completed step.
+    - [ ] Example incomplete step.
+    - [ ] Example partially completed step (completed: X; remaining: Y).
+
+    Use timestamps to measure rates of progress.
+
+    ## Surprises & Discoveries
+
+    Document unexpected behaviors, bugs, optimizations, or insights discovered during implementation. Provide concise evidence.
+
+    - Observation: …
+      Evidence: …
+
+    ## Decision Log
+
+    Record every decision made while working on the plan in the format:
+
+    - Decision: …
+      Rationale: …
+      Date/Author: …
+
+    ## Outcomes & Retrospective
+
+    Summarize outcomes, gaps, and lessons learned at major milestones or at completion. Compare the result against the original purpose.
+
+    ## Context and Orientation
+
+    Describe the current state relevant to this task as if the reader knows nothing. Name the key files and modules by full path. Define any non-obvious term you will use. Do not refer to prior plans.
+
+    ## Plan of Work
+
+    Describe, in prose, the sequence of edits and additions. For each edit, name the file and location (function, module) and what to insert or change. Keep it concrete and minimal.
+
+    ## Concrete Steps
+
+    State the exact commands to run and where to run them (working directory). When a command generates output, show a short expected transcript so the reader can compare. This section must be updated as work proceeds.
+
+    ## Validation and Acceptance
+
+    Describe how to start or exercise the system and what to observe. Phrase acceptance as behavior, with specific inputs and outputs. If tests are involved, say "run <project’s test command> and expect <N> passed; the new test <name> fails before the change and passes after>".
+
+    ## Idempotence and Recovery
+
+    If steps can be repeated safely, say so. If a step is risky, provide a safe retry or rollback path. Keep the environment clean after completion.
+
+    ## Artifacts and Notes
+
+    Include the most important transcripts, diffs, or snippets as indented examples. Keep them concise and focused on what proves success.
+
+    ## Interfaces and Dependencies
+
+    Be prescriptive. Name the libraries, modules, and services to use and why. Specify the types, traits/interfaces, and function signatures that must exist at the end of the milestone. Prefer stable names and paths such as `crate::module::function` or `package.submodule.Interface`. E.g.:
+
+    In crates/foo/planner.rs, define:
+
+        pub trait Planner {
+            fn plan(&self, observed: &Observed) -> Vec<Action>;
+        }
+
+If you follow the guidance above, a single, stateless agent -- or a human novice -- can read your ExecPlan from top to bottom and produce a working, observable result. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED.
+
+When you revise a plan, you must ensure your changes are comprehensively reflected across all sections, including the living document sections, and you must write a note at the bottom of the plan describing the change and the reason why. ExecPlans must describe not just the what but the why for almost everything.

--- a/docs/conventions/file-header-convention.md
+++ b/docs/conventions/file-header-convention.md
@@ -1,0 +1,12 @@
+# File Header Convention
+
+## Rule
+- For newly added source files, use the repository owner's GitHub nickname in the header:
+
+```swift
+//  Created by zaehorang on <date>.
+```
+
+## Notes
+- Do not use assistant/tool names (e.g., `Codex`) in file headers.
+- If a generated file includes a different creator name, normalize it before commit.

--- a/docs/decisions/adr-0001-presentation-architecture.md
+++ b/docs/decisions/adr-0001-presentation-architecture.md
@@ -1,0 +1,87 @@
+# ADR-0001: Presentation Architecture for Refactoring
+
+- Status: Accepted
+- Date: 2026-02-12
+- Owners: FiveGuyes team
+
+## Decision
+
+아키텍처 리팩터링 1차 단계의 Presentation 패턴으로 **Feature 단위 MVVM**을 채택한다.
+상태 흐름은 MVVM 내부에서 단방향 규칙(Action -> ViewModel -> State -> View)으로 강제한다.
+
+## Context
+
+현재 프로젝트는 View 내부에 SwiftData 접근, 비즈니스 로직, UI 로직이 혼재되어 있다.
+동시에 아래 기반은 이미 구현되어 있다.
+
+- Domain 서비스 경계: `BookManagementService`, `DefaultBookManagementService`
+- Data 저장 경계: `BookRepository`, `SwiftDataBookRepository`
+- 계산 로직 V2 + 테스트: `ReadingScheduleCalculatorV2`, `DateMathCalculator`, `PageMathCalculator`
+
+따라서 핵심 과제는 새 패턴을 "처음부터 도입"하는 것이 아니라, 기존 코드를 **안전하게 경계화**하는 것이다.
+
+## Options considered
+
+### Option A: MVVM (선택)
+
+- 장점:
+  - 현재 View 중심 구조에서 점진 이행 비용이 가장 낮다.
+  - 기존 Domain Service 경계를 즉시 활용할 수 있다.
+  - 화면별 테스트(ViewModel 단위)를 빠르게 추가할 수 있다.
+- 단점:
+  - 화면 간 상태/이펙트가 커지면 ViewModel 비대화 위험이 있다.
+  - 규칙 없이 쓰면 양방향 데이터 흐름으로 다시 무너질 수 있다.
+
+### Option B: MVI/Reducer 기반 단방향 아키텍처
+
+- 장점:
+  - 상태/이펙트 추적성이 높고 복잡 화면에서 일관성이 좋다.
+  - 액션 기반 로깅/디버깅에 유리하다.
+- 이번 단계 미선택 이유:
+  - Store/Reducer/Effect 인프라를 새로 깔아야 하며 초기 변경 폭이 크다.
+  - 기존 문제(직접 저장/직접 계산) 해결보다 "프레임워크 전환" 비용이 먼저 발생한다.
+  - 일정과 리스크 기준에서 첫 단계 목표와 맞지 않는다.
+
+### Option C: MV 유지 + 부분 정리
+
+- 장점:
+  - 단기 코드 수정은 가장 빠르다.
+- 미선택 이유:
+  - 근본 문제(테스트 불가, 경계 붕괴, 로직 중복)를 구조적으로 해결하지 못한다.
+
+## Rationale
+
+이번 리팩터링의 목적은 "가장 이상적인 패턴 채택"보다 "운영 중 코드의 안정적 구조화"다.
+MVVM은 기존 코드와 충돌이 적고, 이미 존재하는 Domain/Data 경계를 활용해 빠르게 테스트 가능한 구조로 전환할 수 있다.
+즉, **현재 제약(코드 규모, 일정, 기존 자산)에 대한 최적해**로 MVVM을 선택했다.
+
+## Guardrails
+
+MVVM 채택 시 아래 규칙을 반드시 지킨다.
+
+- View는 SwiftData를 직접 다루지 않는다.
+- View는 계산기/Repository를 직접 호출하지 않는다.
+- ViewModel만 Service 인터페이스를 호출한다.
+- 화면 상태는 ViewModel의 단일 state에서 파생한다.
+- 라우팅 payload는 SwiftData 모델 대신 `id` 또는 Domain DTO를 사용한다.
+
+## Consequences
+
+긍정적 결과:
+- 화면 리팩터링을 단계적으로 수행해도 기능 리스크를 제어할 수 있다.
+- 테스트 경계(ViewModel/Service/Repository)가 명확해진다.
+- 신규 기능이 기존 화면 구조를 오염시키는 속도를 줄인다.
+
+부정적 결과/비용:
+- ViewModel 수와 보일러플레이트가 증가한다.
+- 일부 복잡 플로우에서는 MVI 대비 상태 추적성이 떨어질 수 있다.
+
+## Revisit criteria
+
+아래 조건이 충족되면 MVI(또는 Reducer 기반) 전환을 재검토한다.
+
+- 한 화면의 상태 케이스/사이드이펙트가 지속적으로 증가해 ViewModel 가독성이 악화되는 경우
+- 동일한 상태 전이 버그가 여러 화면에서 반복되는 경우
+- 액션 단위 로깅/리플레이가 제품 운영상 필수로 요구되는 경우
+
+재검토 시에는 전체 전환 대신, 한 기능(예: 홈+일일기록)에서 파일럿 적용 후 확대 여부를 결정한다.

--- a/docs/execplans/mvvm-architecture-refactoring-execplan.md
+++ b/docs/execplans/mvvm-architecture-refactoring-execplan.md
@@ -1,0 +1,221 @@
+# Refactor Reading Flows to a Testable Layered Architecture
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+`PLANS.md` exists at repository root. This plan must be maintained in accordance with `PLANS.md`.
+
+## Purpose / Big Picture
+
+After this change, contributors will be able to add or modify reading features without editing SwiftData persistence logic inside SwiftUI views. User-visible behavior remains the same (book registration, daily reading record, completion flow, date edits), but the execution path becomes: View -> ViewModel -> Domain Service -> Repository. This enables isolated tests for business rules and reduces regressions when changing one screen.
+
+The change is observable when the core screens still behave the same in the simulator, while unit tests cover command flows (`registerBook`, `recordReading`, `completeBook`) without requiring UI rendering.
+
+## Progress
+
+- [x] (2026-02-12 09:23Z) Audited the current codebase and identified boundary violations in main reading flows.
+- [x] (2026-02-12 09:23Z) Wrote architecture baseline in `ARCHITECTURE.md` and established migration design/steps in this ExecPlan.
+- [x] (2026-02-12 09:34Z) Documented presentation architecture choice rationale in ADR `docs/decisions/adr-0001-presentation-architecture.md`.
+- [x] (2026-02-12 09:44Z) Introduced composition root dependencies via `AppDependencies` and injected from `FiveGuyesApp`.
+- [x] (2026-02-12 10:44Z) Migrated `MainHomeView` query state to `MainHomeViewModel` and completed command/query usage through `BookManagementService`.
+- [x] (2026-02-12 10:06Z) Migrated registration flow command path to `registerBook` (`FinishGoalView` now writes through service).
+- [x] (2026-02-12 10:18Z) Migrated completion/edit flows (`CompletionReviewView`, `UnfinishReadingView`, `ReadingDateEditView`) to service commands.
+- [x] (2026-02-12 10:18Z) Removed remaining runtime usage of legacy `ReadingScheduleCalculator` from presentation views (boundary check in `Sources/Presentation/View` returns no matches for `ReadingScheduleCalculator(` and `modelContext` writes).
+- [x] (2026-02-12 10:18Z) Expanded service tests for migrated flows (`updateCompletionReview`, `updateReadingPlan`) and verified full suite with `xcodebuild test`.
+- [x] (2026-02-12 10:44Z) Decoupled major navigation payloads from SwiftData models by switching to `FGUserBook` (`dailyProgress`, `completionCelebration`, `completionReview`, `completionReviewUpdate`, `readingDateEdit`, `unfinishReading`).
+- [x] (2026-02-12 13:40Z) Revalidated full test suite after query/payload refactor (`xcodebuild test` -> `** TEST SUCCEEDED **`).
+- [x] (2026-02-12 13:44Z) Decoupled notification flow from SwiftData payload (`NotiSettingView`, `NotificationManager`, `NotificationType` now use `FGUserBook`; added `FGReadingProgress+Notification` helper extension).
+- [x] (2026-02-12 13:44Z) Revalidated full test suite after notification decoupling (`xcodebuild test` -> `** TEST SUCCEEDED **`).
+
+## Surprises & Discoveries
+
+- Observation: The repository and service boundaries already exist and are usable.
+  Evidence: `FiveGuyes/FiveGuyes/Sources/Domain/Service/BookManagementService.swift`, `FiveGuyes/FiveGuyes/Sources/Domain/Repository/BookRepository.swift`.
+
+- Observation: V2 calculators are implemented and well-tested, but legacy calculators are still invoked from Views.
+  Evidence: `FiveGuyes/FiveGuyes/Sources/Model/V2/ReadingScheduleCalculatorV2.swift` and calls to `ReadingScheduleCalculator` in `MainHomeView.swift`, `DailyProgressView.swift`, `ReadingDateEditView.swift`.
+
+- Observation: Navigation currently passes SwiftData models directly, which couples routing to persistence type details.
+  Evidence: `Screens` enum in `FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NavigationCoordinator.swift`.
+
+- Observation: The first `xcodebuild test` attempt failed because destination/device defaults did not match the test target deployment level.
+  Evidence: `iPhone 16` simulator 18.6 vs test deployment target 26.0 mismatch; rerun on `iPhone 17` simulator (26.2) succeeded.
+
+- Observation: `completeBook` command has broader side effects (notification clear) than "소감 수정" use case requires.
+  Evidence: `DefaultBookManagementService.completeBook` calls `notificationManager.clearRequests()`, so update-mode review save needed a dedicated command (`updateCompletionReview`) to avoid unrelated notification changes.
+
+- Observation: Notification decoupling required moving "next reading day/pages" helper behavior from SwiftData model APIs to domain extension APIs.
+  Evidence: Added `FGReadingProgress+Notification.swift` and switched `NotificationManager`/`NotificationType` inputs to `FGUserBook`.
+
+## Decision Log
+
+- Decision: Keep `DefaultBookManagementService` as the first migration façade instead of splitting into many use case classes immediately.
+  Rationale: It minimizes churn and allows progressive migration screen-by-screen while preserving current tested behavior.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Prioritize Home and Daily Progress flows before registration/completion flows.
+  Rationale: These flows have the highest direct persistence coupling and drive most user sessions.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Define architecture documentation before code migration.
+  Rationale: Existing project instructions require architecture and ExecPlan alignment for significant refactors.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Select Feature MVVM (with unidirectional state rules) instead of immediate MVI migration for phase 1.
+  Rationale: It maximizes incremental migration safety and reuses existing service/repository seams; full MVI infra cost is deferred until complexity thresholds are met.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Keep `DailyProgressView` and `MainHomeView` route payload types unchanged in this step while migrating command execution to service calls.
+  Rationale: It isolates side-effect migration first (direct persistence removal) and avoids cross-screen route breakage during the same patch.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Add dedicated service commands (`updateCompletionReview`, `updateReadingPlan`) instead of overloading `completeBook`.
+  Rationale: `completeBook` includes completion-date mutation and global notification side effects; separating commands preserves behavior parity for update-mode review and reading-date edits.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Keep notification-setting route (`notiSetting`) on SwiftData payload temporarily while decoupling all other major routes to `FGUserBook`.
+  Rationale: Notification layer currently consumes `ReadingProgress`/`UserSettings` APIs from SwiftData model types; forcing full conversion in the same step would mix concerns and increase regression risk.
+  Date/Author: 2026-02-12 / Codex
+
+- Decision: Complete notification layer decoupling in a follow-up step by introducing domain-side helper methods (`findNextReadingDay`, `findNextReadingPagesPerDay`) on `FGReadingProgress`.
+  Rationale: This removes the last presentation-level SwiftData dependency without reintroducing persistence coupling into UI flows.
+  Date/Author: 2026-02-12 / Codex
+
+## Outcomes & Retrospective
+
+Current outcome: composition root wiring is in place (`AppDependencies` injected at app root), and core write paths in reading/registration/completion/date-edit flows now route through domain service boundaries:
+
+- `DailyProgressView` -> `BookManagementService.recordReading`
+- `MainHomeView` delete flow -> `BookManagementService.deleteBook`
+- `MainHomeView` app-open reschedule -> `BookManagementService.rescheduleOnAppOpen`
+- `FinishGoalView` -> `BookManagementService.registerBook`
+- `CompletionReviewView` -> `BookManagementService.completeBook` / `updateCompletionReview`
+- `UnfinishReadingView` -> `BookManagementService.completeBook`
+- `ReadingDateEditView` -> `BookManagementService.updateReadingPlan`
+- `CompletedBooksView` delete flow -> `BookManagementService.deleteBook`
+
+Behavioral parity was validated through repeated `xcodebuild test` runs on iPhone 17 simulator (26.2), including after notification-layer decoupling. `MainHomeView` query state is ViewModel-owned, and all major navigation/notification payloads are now domain-typed (`FGUserBook`). Phase 1 boundary goal is met; optional follow-up work is additional ViewModel extraction for more complex screens.
+
+## Context and Orientation
+
+The current app starts at `FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift` and routes through `NavigationRootView.swift` and `NavigationCoordinator.swift`. Core presentation flows are migrated off direct SwiftData access, including notification settings. Presentation now interacts through domain service/query boundaries and domain payload types.
+
+Domain and data seams already exist:
+
+- Service boundary: `BookManagementService` and `DefaultBookManagementService`
+- Repository boundary: `BookRepository`, `SwiftDataBookRepository`, `MockBookRepository`
+- Pure calculator path: `ReadingScheduleCalculatorV2`, `DateMathCalculator`, `PageMathCalculator`
+
+In this repository, "composition root" means the single place where concrete implementations are created and injected (for example, repository + service instances created in App/Root and passed into ViewModels).
+
+## Plan of Work
+
+Milestone 1 introduces composition root wiring so presentation code receives dependencies through initialization and environment injection instead of creating persistence objects locally. This milestone should not change user-visible behavior.
+
+Milestone 2 migrates read/write-heavy screens (`MainHomeView`, `DailyProgressView`) to ViewModel state and domain commands. Replace `@Query` and `modelContext` writes with service query/command calls and refresh logic.
+
+Milestone 3 migrates registration screens to a single `registerBook` command path. Remove local schedule calculation and persistence from UI. Ensure notification side effects remain triggered from domain service after successful writes.
+
+Milestone 4 migrates completion and date edit flows to service commands (`completeBook` and a settings update command added to the service if needed). Stop direct mutation of SwiftData model properties in Views.
+
+Milestone 5 removes legacy runtime calculator usage from migrated flows and consolidates schedule behavior on V2 calculators. Preserve old code only if still needed by untouched screens.
+
+Milestone 6 expands tests: ViewModel state transitions with mocked service, domain service command paths with mock repository, and existing repository tests retained as persistence contract checks.
+
+## Concrete Steps
+
+Run all commands from repository root `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys`.
+
+1. Audit and track direct SwiftData usage in presentation:
+
+    rg -n "@Environment\\(\\\\.modelContext\\)|@Query|modelContext\\.|UserBookSchemaV2" FiveGuyes/FiveGuyes/Sources/Presentation
+
+2. Build incremental migration branch state:
+
+    git status --short --branch
+
+3. Run unit tests after each milestone:
+
+    xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "id=216C08ED-919D-4095-BF37-CB51C62F71B3"
+
+4. If destination mismatch occurs, discover available destinations and rerun:
+
+    xcodebuild -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -showdestinations
+
+5. Verify boundary cleanup after each migrated flow:
+
+    rg -n "@Environment\\(\\\\.modelContext\\)|@Query|ReadingScheduleCalculator\\(" FiveGuyes/FiveGuyes/Sources/Presentation/View
+
+## Validation and Acceptance
+
+Acceptance is behavior-first:
+
+1. Home screen still shows reading/completed/empty states correctly and supports delete flow.
+2. Daily progress input still supports target-exceeded warning, normal record, date extension, and completion transition.
+3. Registration flow still saves a new book with an initial schedule and returns to root.
+4. Completion flow still stores completion review and completion status.
+5. Existing calculator and repository tests pass, and new ViewModel tests cover success/failure/loading states.
+
+Technical acceptance:
+
+- Migrated views no longer import SwiftData.
+- Migrated views do not call `modelContext.insert/save/delete`.
+- Migrated views do not call legacy `ReadingScheduleCalculator` directly.
+
+## Idempotence and Recovery
+
+The migration is additive and screen-by-screen. Each milestone can be repeated safely because the boundary checks are read-only (`rg`) and tests can be rerun without destructive effects. If a milestone introduces regressions, revert only the touched files for that milestone and rerun tests before continuing. Do not perform destructive repository resets; use targeted file-level rollback commands if needed.
+
+## Artifacts and Notes
+
+Expected boundary-check output should shrink as migration proceeds. Example before migration:
+
+    FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift:23:@Environment(\.modelContext) private var modelContext
+    FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift:35:@Query(...)
+    FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift:8:import SwiftData
+
+Expected service-boundary usage in migrated ViewModel code:
+
+    let books = try await bookManagementService.fetchReadingBooks()
+    let result = try await bookManagementService.recordReading(bookId: id, pagesRead: pages, readDate: date)
+
+## Interfaces and Dependencies
+
+The following interfaces must exist and be the main crossing points by completion:
+
+- `BookManagementService` in `FiveGuyes/FiveGuyes/Sources/Domain/Service/BookManagementService.swift`:
+
+    func registerBook(_ input: RegisterBookInput) async throws -> FGUserBook
+    func recordReading(bookId: UUID, pagesRead: Int, readDate: Date) async throws -> RecordReadingResult
+    func deleteBook(id: UUID) async throws
+    func completeBook(id: UUID, completionDate: Date, review: String) async throws
+    func updateCompletionReview(id: UUID, review: String) async throws
+    func updateReadingPlan(bookId: UUID, startDate: Date, targetEndDate: Date, excludedReadingDays: [Date], today: Date) async throws
+    func fetchReadingBooks() async throws -> [FGUserBook]
+    func fetchCompletedBooks() async throws -> [FGUserBook]
+    func fetchBookDetail(id: UUID) async throws -> FGUserBook
+    func rescheduleOnAppOpen(bookId: UUID, today: Date) async throws
+
+- `BookRepository` in `FiveGuyes/FiveGuyes/Sources/Domain/Repository/BookRepository.swift` remains the persistence contract for domain entities.
+
+- `ReadingScheduleCalculatorV2` in `FiveGuyes/FiveGuyes/Sources/Model/V2/ReadingScheduleCalculatorV2.swift` remains the canonical schedule engine for migrated flows.
+
+New interfaces to add during implementation:
+
+- A presentation dependency container in App layer that exposes:
+
+    var bookManagementService: BookManagementService { get }
+
+- Feature ViewModels (for each migrated flow) that expose:
+
+    load() async
+    handleUserAction(...) async
+    @Published or @Observable state
+
+Revision Note (2026-02-12): Initial plan created to capture architecture design phase outcomes and define implementation milestones for the MV -> layered MVVM refactor.
+Revision Note (2026-02-12): Added ADR linkage and explicit MVVM-vs-MVI decision rationale for presentation architecture selection.
+Revision Note (2026-02-12): Updated with implementation progress (composition root + command-path migration), simulator destination discovery, and latest validation command/result.
+Revision Note (2026-02-12): Completed registration/completion/date-edit command-path migration, removed presentation-side legacy calculator/modelContext writes, added new service commands/tests, and revalidated full test suite.
+Revision Note (2026-02-12): Migrated `MainHomeView` query state to `MainHomeViewModel`, decoupled major route payloads to `FGUserBook`, and recorded notification-layer decoupling as the next remaining boundary task.
+Revision Note (2026-02-12): Removed duplicate refactoring design memo (`docs/architecture-refactoring.md`) and consolidated canonical records into `ARCHITECTURE.md`, ADR, and this ExecPlan.
+Revision Note (2026-02-12): Re-ran full test suite after latest payload/type migration and confirmed `** TEST SUCCEEDED **`.
+Revision Note (2026-02-12): Completed notification-flow decoupling to `FGUserBook` (`NotiSettingView`, `NotificationManager`, `NotificationType`) and revalidated the full test suite with `** TEST SUCCEEDED **`.

--- a/docs/git/git-convention.md
+++ b/docs/git/git-convention.md
@@ -57,14 +57,18 @@ Examples:
    - `git diff [base-branch]...HEAD`
 
 ### PR Writing Rules
-- Write the PR title and description in **English**.
-- Recommended: use the same format as commit messages for the PR title  
-  Example: `feat: add profile edit`
+- Write the PR title and description in **Korean**.
+- Use `.github/pull_request_template.md` as the default PR description format.
+- Recommended: keep commit `type` in English and write the PR title as `<type>: <한글 요약>`  
+  Example: `refactor: 메인 홈 독서 흐름 MVVM 전환`
 
 ### Must Include in PR Description
-- **Summary**: what changed and why (3–5 key lines)
-- **Test Plan**: how you verified it / results (local, simulator, unit tests, etc.)
-- **TODO / Follow-ups**: remaining work and next PR plan
+- `## 📝 작업 내용`
+  - 이번 PR의 핵심 변경 사항과 변경 이유
+  - 테스트 수행 내역/결과
+  - 후속 작업(TODO / Follow-ups)
+- `### 스크린샷 (선택)` 필요 시 첨부
+- `## 💬 리뷰 요구사항(선택)` 리뷰어 확인 포인트 작성
 
 ### Branch Push Rule
 - For the first push of a new branch, set upstream:

--- a/docs/git/git-convention.md
+++ b/docs/git/git-convention.md
@@ -58,18 +58,42 @@ Examples:
 
 ### PR Writing Rules
 - Write the PR title and description in **Korean**.
-- Use `.github/pull_request_template.md` as the default PR description format.
+- If `.github/pull_request_template.md` exists, use it as the default PR description format.
+- If the template file does not exist, use the lightweight format below.
 - Recommended: keep commit `type` in English and write the PR title as `<type>: <한글 요약>`  
   Example: `refactor: 메인 홈 독서 흐름 MVVM 전환`
 
-### Must Include in PR Description
-- `## 📝 작업 내용`
-  - 이번 PR의 핵심 변경 사항과 변경 이유
-  - 테스트 수행 내역/결과
-  - 후속 작업(TODO / Follow-ups)
-- `### 스크린샷 (선택)` 필요 시 첨부
-- `## 💬 리뷰 요구사항(선택)` 리뷰어 확인 포인트 작성
+### Lightweight PR Description (Only when template is missing)
+- `## 작업 내용`
+  - 핵심 변경 사항
+  - 변경 이유
+- `## 테스트`
+  - 수행한 테스트와 결과
+- `## 후속 작업` (optional)
+- `## 리뷰 포인트` (optional)
+- `## 스크린샷` (optional)
 
 ### Branch Push Rule
 - For the first push of a new branch, set upstream:
   - `git push -u origin <branch-name>`
+
+---
+
+## 4) PR Review Convention
+
+### Rules
+- Write review comments in **Korean**.
+- Leave all code findings (bugs, regressions, risks) as **inline comments** on PR diff lines.
+- Do **not** leave only top-level PR comments for code findings.
+- Use one finding per comment with a priority tag: `[P0]`, `[P1]`, `[P2]`, `[P3]`.
+- If inline is impossible, leave a top-level comment and explicitly state why inline is not possible.
+
+### Required Inline Command (`gh`)
+```bash
+gh api -X POST repos/<org>/<repo>/pulls/<pr-number>/comments \
+  -f body='[P1] Finding...' \
+  -f commit_id=<head-commit-sha> \
+  -f path='path/to/file.swift' \
+  -F line=<line-number> \
+  -f side=RIGHT
+```

--- a/docs/git/git-convention.md
+++ b/docs/git/git-convention.md
@@ -1,0 +1,71 @@
+# Git Convention
+
+## 1) Branch Structure & Rules
+
+### Default Branches
+- `main`: Release (production)
+- `develop`: Integration (development baseline)
+
+### Working Branch Principles
+- Always start new work on a **new branch**.
+- Do **not** commit directly to `main`, `develop`, or `dev`.
+- Merge all working branches into `develop`.
+- Merge releases into `main`.
+- When starting implementation (e.g., dev work), if you are on a protected branch (`main` / `develop` / `dev`), **create a working branch immediately**.
+
+### Branch Naming (Recommended)
+- `feature/<key>-<short-description>`
+- `bugfix/<key>-<short-description>`
+- `release/<version>`
+
+Examples:
+- `feature/ABC-123-profile-edit`
+- `bugfix/ABC-456-login-crash`
+- `release/1.2.0`
+
+---
+
+## 2) Commit Convention
+
+### Commit Message Format
+```text
+<type>: <summary>
+
+<optional body>
+```
+
+### Allowed Types
+- `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+
+### Rules
+- Keep `type` in **English**.
+- Write the subject/body in **English**.
+- Keep the subject concise and clearly describe the intent of the change.
+
+Examples:
+- `feat: add profile edit`
+- `fix: handle missing error message on login failure`
+- `refactor: extract profile validation logic`
+
+---
+
+## 3) PR Convention & Workflow
+
+### Before Creating a PR
+1. Review the entire commit history (don’t only look at the latest commit).
+2. Review all changes:
+   - `git diff [base-branch]...HEAD`
+
+### PR Writing Rules
+- Write the PR title and description in **English**.
+- Recommended: use the same format as commit messages for the PR title  
+  Example: `feat: add profile edit`
+
+### Must Include in PR Description
+- **Summary**: what changed and why (3–5 key lines)
+- **Test Plan**: how you verified it / results (local, simulator, unit tests, etc.)
+- **TODO / Follow-ups**: remaining work and next PR plan
+
+### Branch Push Rule
+- For the first push of a new branch, set upstream:
+  - `git push -u origin <branch-name>`

--- a/docs/git/git-convention.md
+++ b/docs/git/git-convention.md
@@ -87,6 +87,13 @@ Examples:
 - Do **not** leave only top-level PR comments for code findings.
 - Use one finding per comment with a priority tag: `[P0]`, `[P1]`, `[P2]`, `[P3]`.
 - If inline is impossible, leave a top-level comment and explicitly state why inline is not possible.
+- When leaving a top-level review comment (summary or fallback), start the first line with `[Agent Review]`.
+
+### Exception: Reviewing Your Own PR
+- GitHub does not allow `request-changes` on your own PR.
+- In this case, keep all findings as inline comments (same as normal review).
+- Use a top-level `--comment` review only as a summary; do not replace inline findings with top-level-only comments.
+- If you must use top-level comments for a finding, explicitly explain why inline was not possible.
 
 ### Required Inline Command (`gh`)
 ```bash

--- a/docs/references/architecture-doc.md
+++ b/docs/references/architecture-doc.md
@@ -1,0 +1,169 @@
+# ARCHITECTURE doc
+
+> This document is a **reference guide** for writing the project's `ARCHITECTURE.md`.
+> It is **not** the architecture document itself.
+
+**Goal**
+Help recurring contributors/reviewers quickly answer:
+- “Where do I change this?”
+- “What does the thing I’m looking at do?”
+
+**Core rules**
+- Keep it **short** and write only things that **don’t change often**.
+- Do **not** try to keep this in 1:1 sync with code.
+- Prefer naming important files/modules/types, but avoid links (links go stale). Use symbol search.
+- State **architectural invariants** explicitly (often expressed as “there is no X”).
+- Document **boundaries** explicitly (good boundaries are hard to discover by randomly reading code).
+- Revisit the doc only occasionally (e.g., a couple of times a year), not on every change.
+
+---
+
+## 0) Scope
+
+### Audience
+- Recurring contributors
+- Reviewers for large or cross-cutting changes
+
+### Non-goals
+- Detailed “how it works internally” for each module
+- Tutorials / API reference
+- Exhaustive lists of every function/type/file
+
+Rule of thumb:
+- This document is a **country map**, not an atlas.
+
+---
+
+## 1) Update policy
+
+- Do not update this doc for every change.
+- Revisit on a slow cadence (e.g., twice a year).
+- If a section drifts toward fast-changing details, delete/shorten it.
+- If in doubt: remove detail and keep only stable constraints and navigation pointers.
+
+---
+
+## 2) Bird’s-eye view
+
+Write a brief high-level overview to anchor the reader’s mental model.
+
+### 2.1 System overview (1–2 paragraphs)
+- What is the system at the highest level?
+- What does it accept and what does it produce?
+
+### 2.2 Inputs → Outputs (Ground vs Derived)
+- **Inputs (ground state):** authoritative facts the system consumes (source of truth)
+- **Outputs (derived state):** everything computed from inputs (rebuildable caches/models/artifacts)
+
+Example shape:
+- Input: `<input facts / shapes>`
+- Output: `<derived state / artifacts>`
+
+### 2.3 Update model
+- What constitutes a “small change”?
+- How does the system react (incremental? lazy/on-demand?)?
+
+---
+
+## 3) Entry points
+
+List onboarding-friendly starting points to read code.
+
+- Main entry point(s): `<path(s)>`
+- Request/command handling entry points: `<path(s)>`
+- Main façade API type(s): `<type/module names>`
+
+Guideline:
+- Use **real names** (paths/types), not placeholders.
+
+---
+
+## 4) Code map
+
+The code map must answer:
+1) “Where is the thing that does X?”
+2) “What does the thing I’m looking at do?”
+
+### 4.1 Top-level repository map
+List the major directories/modules/packages:
+
+- `/<dir-or-package-1>`: one-line description
+- `/<dir-or-package-2>`: one-line description
+- `/<dir-or-package-3>`: one-line description
+
+Sanity check:
+- Things that should be close conceptually should also be close in the repo layout.
+
+### 4.2 Major components (coarse-grained)
+
+For each major component, keep it short (~3–7 bullets):
+
+#### Component: `<real name>`
+- Responsibility: …
+- Owns (data/state): …
+- Depends on: …
+- Must **not** depend on: …
+- Boundary status: (Is this an API/boundary surface?)
+- Key invariants: …
+
+---
+
+## 5) Architectural invariants
+
+Important invariants are often best expressed as **absence** (“there is no X”).
+State them explicitly because they are hard to infer from code.
+
+Use this shape:
+
+**Architecture Invariant:** <rule / forbidden dependency / absence>
+- Rationale: <why it matters>
+- Enforced by: <module boundary / type system / tests / conventions>
+- Violation symptoms: <what breaks if violated>
+
+Guideline:
+- Aim for ~3–7 invariants. Keep only the foundational ones.
+
+---
+
+## 6) Boundaries & API surfaces
+
+Document boundaries because they are hard to find by randomly reading files.
+
+### 6.1 Boundary list
+- Boundary surface A: `<module/path>`
+  - What crosses this boundary?
+  - What is forbidden to cross?
+- Boundary surface B: `<module/path>`
+  - …
+
+### 6.2 Boundary rules (“only here”)
+Fill in the places where special rules apply:
+
+- Serialization / DTO conversion happens in: `<module/path>` (only here)
+- IO happens in: `<module/path>` (only here)
+- Protocol handling happens in: `<module/path>` (only here)
+
+---
+
+## 7) Cross-cutting concerns
+
+After the code map, add cross-cutting concerns as a separate section.
+Include only stable, project-defining topics.
+
+Suggested topics (pick only what matters):
+- Code generation (what, how, policy)
+- Cancellation / stale work handling (if applicable)
+- Testing strategy organized by boundaries
+- Error handling strategy
+
+Guideline:
+- Keep each subsection short; if it grows, move details elsewhere.
+
+---
+
+## 8) Writing constraints (keep it maintainable)
+
+- Prefer naming files/modules/types; avoid links (use symbol search).
+- Avoid module-internal implementation details.
+- Keep it short and stable; delete detail when it stops being stable.
+


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 서비스 기반 MVVM 전환: `AppDependencies` 도입 및 `BookManagementService` 환경 주입으로 View의 SwiftData 직접 접근 의존성을 줄였습니다.
- `MainHomeViewModel`을 추가해 홈 화면의 조회/삭제/재분배 로직을 View에서 분리했습니다.
- `BookManagementService`/`DefaultBookManagementService` API를 확장해 조회·재분배·독서 플랜 변경 로직을 도메인 계층으로 단일화했습니다.
- 아키텍처 문서를 정비했습니다. (`ARCHITECTURE.md`, ADR, ExecPlan, Git Convention 등)
- PR 규칙 문서를 한국어 + PR 템플릿 기준으로 수정했습니다. (`docs/git/git-convention.md`)
- 테스트 결과
  - `xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "id=216C08ED-919D-4095-BF37-CB51C62F71B3"`
  - `** TEST SUCCEEDED **`
- 후속 작업
  - 남은 화면의 ViewModel 분리 및 공통 패턴 적용
  - `MainHomeViewModel` 단위 테스트 보강
  - Service command 경계 케이스 테스트 확장

### 스크린샷 (선택)
<img src="" width="300"/>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- `MainHomeView`와 `MainHomeViewModel` 사이 책임 경계가 적절한지 확인 부탁드립니다.
- `BookManagementService` API 확장 범위가 이후 화면 확장에도 유지 가능한지 검토 부탁드립니다.
