### PR TITLE
refactor: Phase 2 MVVM 뷰모델 추출 및 테스트 보강

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,17 @@ When creating or updating architecture documentation, follow:
 
 # Git Conventions
 
-For Git workflow (branching, commit, PR preparation, PR review), follow:
+For Git workflow (branching, commit), follow:
 - `./docs/git/git-convention.md`
+
+For PR workflow (preparation, writing, review), follow:
+- `./docs/git/pr-convention.md`
+
+When performing PR review, you must:
+- Review full commit history and full diff against the base branch.
+- Leave code findings as inline comments with `[P0]`~`[P3]` priority tags.
+- Avoid top-level-only findings; use top-level comment only for summary/fallback with reason.
+- If another agent is actively working on the same PR/branch, refresh and re-check latest `HEAD` before submitting review comments.
 
 # File Header Convention
 

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionReviewView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionReviewView.swift
@@ -10,9 +10,7 @@ import SwiftUI
 struct CompletionReviewView: View {
     private let placeholder: String = "책 속 한 줄이 남긴 여운은 무엇인가요?"
     
-    @State private var reflectionText: String = ""
-    @State private var showAlert = false
-    @State private var isSubmitting = false
+    @State private var viewModel = CompletionReviewViewModel()
     @FocusState private var isFocusedTextEditor: Bool
     @ObservedObject private var keyboardObserver = KeyboardObserver()
     
@@ -26,6 +24,7 @@ struct CompletionReviewView: View {
     let userBook: FGUserBook
     
     var body: some View {
+        @Bindable var bindableViewModel = viewModel
         let title = userBook.bookMetaData.title
         
         ZStack {
@@ -41,8 +40,11 @@ struct CompletionReviewView: View {
                     .foregroundStyle(Color.Labels.primaryBlack1)
                     .lineLimit(1)
                     
-                    TextEditor(text: $reflectionText)
-                        .customStyleEditor(placeholder: placeholder, userInput: $reflectionText)
+                    TextEditor(text: $bindableViewModel.reflectionText)
+                        .customStyleEditor(
+                            placeholder: placeholder,
+                            userInput: $bindableViewModel.reflectionText
+                        )
                         .frame(height: 222)
                         .focused($isFocusedTextEditor)
                 }
@@ -52,7 +54,9 @@ struct CompletionReviewView: View {
                 
                 if keyboardObserver.keyboardIsVisible {
                     Button {
-                        submitReview()
+                        Task {
+                            await submitReview()
+                        }
                     } label: {
                         Text("저장")
                             .frame(maxWidth: .infinity)
@@ -61,59 +65,33 @@ struct CompletionReviewView: View {
                             .foregroundStyle(Color.Fills.white)
                     }
                     .ignoresSafeArea(.keyboard, edges: .bottom)
-                    .disabled(isSubmitting)
+                    .disabled(viewModel.isSubmitting)
                 }
             }
         }
-        .alert(isPresented: $showAlert) {
+        .alert(isPresented: $bindableViewModel.showEmptyReviewAlert) {
             Alert(title: Text("내용을 입력해주세요")
                 .alertFontStyle(.title3, weight: .semibold),
                   dismissButton: .default(Text("확인")))
         }
         .customNavigationBackButton()
         .onAppear {
-            reflectionText = userBook.completionStatus.reviewAfterCompletion
+            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
+            viewModel.preloadReview(userBook.completionStatus.reviewAfterCompletion)
             isFocusedTextEditor = true
         }
     }
 
     @MainActor
-    private func submitReview() {
-        guard !isSubmitting else { return }
+    private func submitReview() async {
+        let outcome = await viewModel.submit(
+            userBookId: userBook.id,
+            isUpdateMode: isUpdateMode,
+            completionDate: Date().adjustedDate()
+        )
 
-        if reflectionText.isEmpty {
-            showAlert = true
-            return
-        }
-
-        isSubmitting = true
-        let review = reflectionText
-
-        Task {
-            do {
-                if isUpdateMode {
-                    try await appDependencies.bookManagementService.updateCompletionReview(
-                        id: userBook.id,
-                        review: review
-                    )
-                } else {
-                    try await appDependencies.bookManagementService.completeBook(
-                        id: userBook.id,
-                        completionDate: Date().adjustedDate(),
-                        review: review
-                    )
-                }
-
-                await MainActor.run {
-                    isSubmitting = false
-                    navigationCoordinator.popToRoot()
-                }
-            } catch {
-                await MainActor.run {
-                    isSubmitting = false
-                }
-                print("완독 소감 저장 중 오류 발생: \(error.localizedDescription)")
-            }
+        if case .popToRoot = outcome {
+            navigationCoordinator.popToRoot()
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
@@ -8,9 +8,7 @@
 import SwiftUI
 
 struct DailyProgressView: View {
-    @State private var pagesToReadToday: Int = 0
-    @State private var showAlert = false
-    @State private var isSubmitting = false
+    @State private var viewModel = DailyProgressViewModel()
     
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
     @Environment(AppDependencies.self) private var appDependencies
@@ -25,6 +23,7 @@ struct DailyProgressView: View {
     let userBook: FGUserBook
     
     var body: some View {
+        @Bindable var bindableViewModel = viewModel
         let title = userBook.bookMetaData.title
         let targetEndPage = userBook.userSettings.targetEndPage
         let targetEndDate = userBook.userSettings.targetEndDate
@@ -45,7 +44,7 @@ struct DailyProgressView: View {
             HStack {
                 Spacer()
                 
-                TextField("", value: $pagesToReadToday, format: .number)
+                TextField("", value: $bindableViewModel.pagesToReadToday, format: .number)
                     .frame(width: 180, height: 68)
                     .background(Color.Fills.lightGreen)
                     .cornerRadius(16)
@@ -66,13 +65,11 @@ struct DailyProgressView: View {
             
             if isTextTextFieldFocused {
                 Button {
-                    if pagesToReadToday > targetEndPage {
-                        // 최종 목표보다 더 큰 페이지를 입력하면
-                        showAlert = true
-                        return
+                    if viewModel.requestSubmit(targetEndPage: targetEndPage) {
+                        Task {
+                            await submitReading()
+                        }
                     }
-
-                    submitReading()
                 } label: {
                     Text("완료")
                         .frame(maxWidth: .infinity)
@@ -82,11 +79,11 @@ struct DailyProgressView: View {
                     
                 }
                 .ignoresSafeArea(.keyboard, edges: .bottom)
-                .disabled(isSubmitting)
+                .disabled(viewModel.isSubmitting)
             }
             
         }
-        .alert(isPresented: $showAlert) {
+        .alert(isPresented: $bindableViewModel.showTargetExceededAlert) {
             // TODO: 커스텀스타일 적용 어려워서 임의로 스타일 지정함 확인필요
             Alert(
                 title: Text(alertText)
@@ -95,24 +92,23 @@ struct DailyProgressView: View {
                     .alertFontStyle(.caption1),
                 primaryButton: .cancel(Text("다시 작성하기")) {
                     // "다시 작성하기" 로직 (입력값 초기화)
-                    pagesToReadToday = 0
+                    viewModel.pagesToReadToday = 0
                     isTextTextFieldFocused = true
                 },
                 secondaryButton: .default(Text("확인")) {
                     // "확인" 버튼 로직 (최종 타켓 페이지로 수정 및 완독 기록)
-                    pagesToReadToday = targetEndPage
-                    submitReading()
+                    viewModel.applyMaximumTargetPages(targetEndPage)
+                    Task {
+                        await submitReading()
+                    }
                 }
             )
         }
         .navigationTitle("오늘 독서 현황 기록하기")
         .customNavigationBackButton()
         .onAppear {
-            // ⏰
-            if let readingRecord = userBook.readingProgress.getDailyReadingRecord(for: adjustedToday) {
-                pagesToReadToday = readingRecord.targetPages
-            }
-            
+            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
+            viewModel.preloadPages(userBook: userBook, adjustedToday: adjustedToday)
             isTextTextFieldFocused = true
         }
         .onAppear {
@@ -122,43 +118,14 @@ struct DailyProgressView: View {
     }
 
     @MainActor
-    private func submitReading() {
-        guard !isSubmitting else { return }
-        isSubmitting = true
-
-        let pagesRead = pagesToReadToday
-        Task {
-            do {
-                let result = try await appDependencies.bookManagementService.recordReading(
-                    bookId: userBook.id,
-                    pagesRead: pagesRead,
-                    readDate: adjustedToday
-                )
-
-                await MainActor.run {
-                    isSubmitting = false
-                    handleRecordResult(result)
-                }
-            } catch {
-                await MainActor.run {
-                    isSubmitting = false
-                }
-                print("독서 기록 저장 중 오류 발생: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    @MainActor
-    private func handleRecordResult(_ result: RecordReadingResult) {
-        switch result {
-        case .recorded:
+    private func submitReading() async {
+        switch await viewModel.submit(bookId: userBook.id, readDate: adjustedToday) {
+        case .none:
+            return
+        case .popToRoot:
             navigationCoordinator.popToRoot()
-        case .dateExtended:
-            navigationCoordinator.popToRoot()
-        case .completed(let updatedBook):
+        case .completionCelebration(let updatedBook):
             navigationCoordinator.push(.completionCelebration(book: updatedBook))
-        case .exceedsTarget:
-            showAlert = true
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
@@ -11,6 +11,7 @@ struct UnfinishReadingView: View {
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
     @Environment(AppDependencies.self) private var appDependencies
 
+    @State private var viewModel = UnfinishReadingViewModel()
     private let userBook: FGUserBook
     
     // MARK: - init
@@ -56,6 +57,9 @@ struct UnfinishReadingView: View {
         .disableNavigationGesture()
         .customNavigationBackButton {
             markBookAsCompletedInBackground()
+        }
+        .onAppear {
+            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
         }
     }
     
@@ -111,7 +115,7 @@ struct UnfinishReadingView: View {
             }
     }
     
-    private func readingDateEtidButton(actions: @escaping () -> ()) -> some View {
+    private func readingDateEtidButton(actions: @escaping () -> Void) -> some View {
         Button(action: actions) {
             Text("목표 기간 연장하기")
                 .fontStyle(.title2, weight: .semibold)
@@ -123,9 +127,10 @@ struct UnfinishReadingView: View {
                         .foregroundStyle(Color.Colors.green1)
                 }
         }
+        .disabled(viewModel.isCompleting)
     }
     
-    private func cancelButton(actions: @escaping () -> ()) -> some View {
+    private func cancelButton(actions: @escaping () -> Void) -> some View {
         Button(action: actions) {
             Text("닫기")
                 .fontStyle(.title2, weight: .semibold)
@@ -136,35 +141,20 @@ struct UnfinishReadingView: View {
                         .foregroundStyle(Color.Fills.white)
                 }
         }
+        .disabled(viewModel.isCompleting)
     }
     
     // MARK: - Helper Methods
     
     @MainActor
     private func completeAndPopToRoot() async {
-        do {
-            try await appDependencies.bookManagementService.completeBook(
-                id: userBook.id,
-                completionDate: userBook.userSettings.targetEndDate,
-                review: ""
-            )
-        } catch {
-            print("미완독 종료 처리 중 오류 발생: \(error.localizedDescription)")
-        }
+        _ = await viewModel.completeBook(userBook)
         navigationCoordinator.popToRoot()
     }
 
     private func markBookAsCompletedInBackground() {
         Task {
-            do {
-                try await appDependencies.bookManagementService.completeBook(
-                    id: userBook.id,
-                    completionDate: userBook.userSettings.targetEndDate,
-                    review: ""
-                )
-            } catch {
-                print("미완독 종료 처리 중 오류 발생: \(error.localizedDescription)")
-            }
+            _ = await viewModel.completeBook(userBook)
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
@@ -148,8 +148,11 @@ struct UnfinishReadingView: View {
     
     @MainActor
     private func completeAndPopToRoot() async {
-        _ = await viewModel.completeBook(userBook)
-        navigationCoordinator.popToRoot()
+        let isCompleted = await viewModel.completeBook(userBook)
+
+        if isCompleted {
+            navigationCoordinator.popToRoot()
+        }
     }
 
     private func markBookAsCompletedInBackground() {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
@@ -12,8 +12,7 @@ struct FinishGoalView: View {
     @Environment(BookSettingInputModel.self) var bookSettingInputModel: BookSettingInputModel
     @Environment(AppDependencies.self) private var appDependencies
     
-    @State private var pagesPerDay: Int = 0
-    @State private var isSubmitting = false
+    @State private var viewModel = FinishGoalViewModel()
     
     var body: some View {
         
@@ -49,7 +48,7 @@ struct FinishGoalView: View {
                     HStack(spacing: 0) {
                         TextView(text: "매일 ")
                         
-                        Text("\(pagesPerDay)")
+                        Text("\(viewModel.pagesPerDay)")
                             .fontStyle(.title1, weight: .semibold)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
@@ -110,7 +109,7 @@ struct FinishGoalView: View {
                                 .cornerRadius(8)
                             
                             // 하루 권장 독서량
-                            Text("하루 권장 독서량 : \(pagesPerDay)쪽")
+                            Text("하루 권장 독서량 : \(viewModel.pagesPerDay)쪽")
                                 .foregroundStyle(Color.Colors.green2)
                                 .fontStyle(.body)
                                 .lineLimit(1)
@@ -135,13 +134,15 @@ struct FinishGoalView: View {
                     Spacer()
                     
                     Button {
-                        registerBook(
-                            selectedBook: book,
-                            startPage: startPage,
-                            targetEndPage: totalPages,
-                            startDate: startDate,
-                            endDate: endDate
-                        )
+                        Task {
+                            await registerBook(
+                                selectedBook: book,
+                                startPage: startPage,
+                                targetEndPage: totalPages,
+                                startDate: startDate,
+                                endDate: endDate
+                            )
+                        }
                     } label: {
                         HStack {
                             Text("확인")
@@ -155,17 +156,19 @@ struct FinishGoalView: View {
                         .cornerRadius(16)
                         .padding(.horizontal, 16)
                     }
-                    .disabled(isSubmitting)
+                    .disabled(viewModel.isSubmitting)
                     
                 }
                 
             }
             .onAppear {
-                calculateRecommendedPagesPerDay(
+                viewModel.configure(bookManagementService: appDependencies.bookManagementService)
+                viewModel.calculateRecommendedPagesPerDay(
                     startPage: startPage,
                     targetEndPage: totalPages,
                     startDate: startDate,
-                    endDate: endDate
+                    endDate: endDate,
+                    excludedDays: bookSettingInputModel.nonReadingDays
                 )
             }
             .onAppear {
@@ -176,32 +179,6 @@ struct FinishGoalView: View {
         
     }
 
-    private func calculateRecommendedPagesPerDay(
-        startPage: Int,
-        targetEndPage: Int,
-        startDate: Date,
-        endDate: Date
-    ) {
-        let excludedDays = bookSettingInputModel.nonReadingDays
-        let totalDays = try? ReadingDateCalculator().calculateValidReadingDays(
-            startDate: startDate,
-            endDate: endDate,
-            excludedDates: excludedDays
-        )
-
-        guard let totalDays, totalDays > 0 else {
-            pagesPerDay = 0
-            return
-        }
-
-        pagesPerDay = ReadingPagesCalculator()
-            .calculatePagesPerDayAndRemainder(
-                totalDays: totalDays,
-                startPage: startPage,
-                endPage: targetEndPage
-            ).pagesPerDay
-    }
-
     @MainActor
     private func registerBook(
         selectedBook: Book,
@@ -209,39 +186,18 @@ struct FinishGoalView: View {
         targetEndPage: Int,
         startDate: Date,
         endDate: Date
-    ) {
-        guard !isSubmitting else { return }
-        isSubmitting = true
-
-        let input = RegisterBookInput(
-            bookMetaData: FGBookMetaData(
-                title: selectedBook.title,
-                author: selectedBook.author,
-                coverImageURL: selectedBook.cover,
-                totalPages: targetEndPage
-            ),
-            userSettings: FGUserSetting(
-                startPage: startPage,
-                targetEndPage: targetEndPage,
-                startDate: startDate,
-                targetEndDate: endDate,
-                excludedReadingDays: bookSettingInputModel.nonReadingDays
-            )
+    ) async {
+        let registered = await viewModel.registerBook(
+            selectedBook: selectedBook,
+            startPage: startPage,
+            targetEndPage: targetEndPage,
+            startDate: startDate,
+            endDate: endDate,
+            excludedReadingDays: bookSettingInputModel.nonReadingDays
         )
 
-        Task {
-            do {
-                _ = try await appDependencies.bookManagementService.registerBook(input)
-                await MainActor.run {
-                    isSubmitting = false
-                    navigationCoordinator.popToRoot()
-                }
-            } catch {
-                await MainActor.run {
-                    isSubmitting = false
-                }
-                print("책 등록 중 오류 발생: \(error.localizedDescription)")
-            }
+        if registered {
+            navigationCoordinator.popToRoot()
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
@@ -10,35 +10,16 @@ import SwiftUI
 struct NotiSettingView: View {
     @Environment(\.scenePhase) private var scenePhase // 앱 상태 감지
     
-    @State private var selectedTime: Date = Date() // 데이트 피커에 사용될 시간
-    
-    @State private var isNotificationDisabled: Bool = false // 모든 알람 수신 토글
-    @State private var isReminderTimePickerVisible: Bool = false // 데이트 피커 표시 여부
-    @State private var isSystemNotificationEnabled = true // 시스템 노티 권한 여부
-    
-    @State private var notificationStatusTask: Task<Void, Never>?
-    @State private var notificationTimeTask: Task<Void, Never>?
+    @State private var viewModel = NotiSettingViewModel()
     
     let userBook: FGUserBook?
-    
-    private let notificationManager = NotificationManager()
     
     // Toggle 바인딩 변수
     private var isNotificationToggleEnabled: Binding<Bool> {
         Binding(
-            get: { !isNotificationDisabled },
-            set: { isNotificationDisabled = !$0 }
+            get: { !viewModel.isNotificationDisabled },
+            set: { viewModel.isNotificationDisabled = !$0 }
         )
-    }
-    
-    // 시간 범위 설정: 04:00 ~ 23:55
-    private var timeSelectionRange: ClosedRange<Date> {
-        let calendar = Calendar.app
-        let now = Date()
-        let startOfDay = calendar.startOfDay(for: now)
-        let start = calendar.date(bySettingHour: 4, minute: 0, second: 0, of: startOfDay)!
-        let end = calendar.date(bySettingHour: 23, minute: 55, second: 0, of: startOfDay)!
-        return start...end
     }
     
     var body: some View {
@@ -47,7 +28,7 @@ struct NotiSettingView: View {
                 .ignoresSafeArea()
             
             VStack(alignment: .leading, spacing: .zero) {
-                if !isSystemNotificationEnabled {
+                if !viewModel.isSystemNotificationEnabled {
                     notificationDisabledView
                 }
                 
@@ -60,7 +41,7 @@ struct NotiSettingView: View {
                 timePickerSection
                     .padding(.top, 16)
                 
-                if isReminderTimePickerVisible {
+                if viewModel.isReminderTimePickerVisible {
                     timePicker
                 }
                 
@@ -72,34 +53,21 @@ struct NotiSettingView: View {
         .navigationTitle("알림 설정")
         .customNavigationBackButton()
         .task {
-            isSystemNotificationEnabled = await notificationManager.requestAuthorization()
+            await viewModel.refreshSystemNotificationAuthorization()
         }
         .onAppear {
-            fetchNotificationTime()
-            fetchNotificationDisabled()
+            viewModel.loadPersistedSettings()
         }
-        .onChange(of: isNotificationDisabled) {
-            // 기존 Task 취소
-            notificationStatusTask?.cancel()
-            
-            // 새로운 Task 생성
-            notificationStatusTask = Task {
-                await handleNotificationStatusChange(isDisabled: isNotificationDisabled, userBook: userBook)
-            }
+        .onChange(of: viewModel.isNotificationDisabled) {
+            viewModel.handleNotificationStatusChange(userBook: userBook)
         }
-        .onChange(of: selectedTime) {
-            // 기존 Task 취소
-            notificationTimeTask?.cancel()
-            
-            // 새로운 Task 생성
-            notificationTimeTask = Task {
-                await handleNotificationTimeChange(newTime: selectedTime, userBook: userBook)
-            }
+        .onChange(of: viewModel.selectedTime) {
+            viewModel.handleNotificationTimeChange(userBook: userBook)
         }
         .onChange(of: scenePhase) {
             if scenePhase == .active { // 시스템 설정에 갔다가 다시 오는 상황 체크
                 Task {
-                    isSystemNotificationEnabled = await notificationManager.requestAuthorization()
+                    await viewModel.refreshSystemNotificationAuthorization()
                 }
             }
         }
@@ -178,10 +146,10 @@ struct NotiSettingView: View {
     private var timerPickerButton: some View {
         Button {
             withAnimation(.easeIn) {
-                isReminderTimePickerVisible.toggle()
+                viewModel.isReminderTimePickerVisible.toggle()
             }
         } label: {
-            Text(selectedTime, style: .time)
+            Text(viewModel.selectedTime, style: .time)
                 .fontStyle(.body)
                 .foregroundStyle(Color.Colors.green2)
                 .multilineTextAlignment(.center)
@@ -196,11 +164,12 @@ struct NotiSettingView: View {
     
     // 실제로 데이터 피커가 보이는곳에 쓰이는 피커 컴포넌트
     private var timePicker: some View {
-        VStack {
+        @Bindable var bindableViewModel = viewModel
+        return VStack {
             DatePicker(
                 "",
-                selection: $selectedTime,
-                in: timeSelectionRange,
+                selection: $bindableViewModel.selectedTime,
+                in: viewModel.timeSelectionRange,
                 displayedComponents: .hourAndMinute
             )
             .datePickerStyle(WheelDatePickerStyle())
@@ -213,55 +182,5 @@ struct NotiSettingView: View {
         .onDisappear {
             UIDatePicker.appearance().minuteInterval = 1
         }
-    }
-    
-    // MARK: - Method
-    // 시간과 분만 저장
-    private func saveNotificationTime(_ time: Date) {
-        let calendar = Calendar.app
-        let hour = calendar.component(.hour, from: time)
-        let minute = calendar.component(.minute, from: time)
-        print("Save: \(hour): \(minute)")
-        
-        UserDefaultsManager.saveNotificationTime(hour: hour, minute: minute)
-    }
-    
-    private func saveNotificationStatus(_ isNotificationDisabled: Bool) {
-        UserDefaultsManager.saveNotificationDisabled(isNotificationDisabled)
-    }
-    
-    // 저장된 시간과 분 불러오기
-    private func fetchNotificationTime() {
-        let calendar = Calendar.app
-        let (hour, minute) = UserDefaultsManager.fetchNotificationReminderTime()
-        
-        selectedTime =
-        calendar.date(bySettingHour: hour, minute: minute, second: 0, of: Date()) ?? Date()
-    }
-    
-    private func fetchNotificationDisabled() {
-        isNotificationDisabled = UserDefaultsManager.fetchNotificationDisabled()
-    }
-    
-    private func handleNotificationStatusChange(isDisabled: Bool, userBook: FGUserBook?) async {
-        saveNotificationStatus(isDisabled)
-        
-        // 등록된 책이 없을 때는 노티 설정 X
-        guard let userBook else { return }
-        
-        if isDisabled {
-            await notificationManager.clearRequests()
-        } else {
-            await notificationManager.setupAllNotifications(userBook)
-        }
-    }
-    
-    private func handleNotificationTimeChange(newTime: Date, userBook: FGUserBook?) async {
-        saveNotificationTime(newTime)
-        
-        // 등록된 책이 없을 때는 노티 설정 X
-        guard let userBook else { return }
-        
-        await notificationManager.updateNotification(notificationType: .morning(readingBook: userBook))
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
@@ -13,8 +13,8 @@ struct ReadingDateEditView: View {
     
     private let userBook: FGUserBook
     
+    @State private var viewModel = ReadingDateEditViewModel()
     @StateObject private var calendarCellModel: CalendarCellModel
-    @State private var isSubmitting = false
     
     private var adjustedToday: Date
     private let calendarCalculator = CalendarCalculator()
@@ -85,6 +85,9 @@ struct ReadingDateEditView: View {
         }
         .navigationTitle("목표기간 수정하기")
         .customNavigationBackButton()
+        .onAppear {
+            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
+        }
     }
     
     private func descriptionText() -> some View {
@@ -107,7 +110,9 @@ struct ReadingDateEditView: View {
                     calendarCellModel.confirmDates()
                 }
             } else {
-                submitReadingPlanUpdate()
+                Task {
+                    await submitReadingPlanUpdate()
+                }
             }
         } label: {
             RoundedRectangle(cornerRadius: 16)
@@ -124,7 +129,7 @@ struct ReadingDateEditView: View {
         .padding(.top, 14)
         .padding(.bottom, 21)
         .padding(.horizontal, 16)
-        .disabled(!calendarCellModel.isRangeComplete() || isSubmitting)
+        .disabled(!calendarCellModel.isRangeComplete() || viewModel.isSubmitting)
     }
     
     private func goalSelectionText() -> some View {
@@ -162,34 +167,22 @@ struct ReadingDateEditView: View {
     }
 
     @MainActor
-    private func submitReadingPlanUpdate() {
-        guard !isSubmitting else { return }
+    private func submitReadingPlanUpdate() async {
         guard let startDate = calendarCellModel.getStartDate(),
               let endDate = calendarCellModel.getEndDate() else { return }
 
-        isSubmitting = true
         let excludedDays = calendarCellModel.getExcludedDates()
 
-        Task {
-            do {
-                try await appDependencies.bookManagementService.updateReadingPlan(
-                    bookId: userBook.id,
-                    startDate: startDate,
-                    targetEndDate: endDate,
-                    excludedReadingDays: excludedDays,
-                    today: adjustedToday
-                )
+        let isUpdated = await viewModel.submitReadingPlanUpdate(
+            bookId: userBook.id,
+            startDate: startDate,
+            endDate: endDate,
+            excludedReadingDays: excludedDays,
+            today: adjustedToday
+        )
 
-                await MainActor.run {
-                    isSubmitting = false
-                    navigationCoordinator.popToRoot()
-                }
-            } catch {
-                await MainActor.run {
-                    isSubmitting = false
-                }
-                print("목표기간 수정 저장 중 오류 발생: \(error.localizedDescription)")
-            }
+        if isUpdated {
+            navigationCoordinator.popToRoot()
         }
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/CompletionReviewViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/CompletionReviewViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  CompletionReviewViewModel.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CompletionReviewViewModel {
+    enum SubmitOutcome {
+        case none
+        case popToRoot
+    }
+
+    var reflectionText = ""
+    var showEmptyReviewAlert = false
+    private(set) var isSubmitting = false
+
+    private var bookManagementService: (any BookManagementService)?
+
+    func configure(bookManagementService: any BookManagementService) {
+        guard self.bookManagementService == nil else { return }
+        self.bookManagementService = bookManagementService
+    }
+
+    func preloadReview(_ review: String) {
+        reflectionText = review
+    }
+
+    func submit(userBookId: UUID, isUpdateMode: Bool, completionDate: Date) async -> SubmitOutcome {
+        guard !isSubmitting else { return .none }
+
+        let review = reflectionText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !review.isEmpty else {
+            showEmptyReviewAlert = true
+            return .none
+        }
+
+        guard let bookManagementService else { return .none }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        do {
+            if isUpdateMode {
+                try await bookManagementService.updateCompletionReview(
+                    id: userBookId,
+                    review: review
+                )
+            } else {
+                try await bookManagementService.completeBook(
+                    id: userBookId,
+                    completionDate: completionDate,
+                    review: review
+                )
+            }
+            return .popToRoot
+        } catch {
+            print("완독 소감 저장 중 오류 발생: \(error.localizedDescription)")
+            return .none
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/DailyProgressViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/DailyProgressViewModel.swift
@@ -1,0 +1,77 @@
+//
+//  DailyProgressViewModel.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class DailyProgressViewModel {
+    enum SubmitOutcome {
+        case none
+        case popToRoot
+        case completionCelebration(book: FGUserBook)
+    }
+
+    var pagesToReadToday: Int = 0
+    var showTargetExceededAlert = false
+    private(set) var isSubmitting = false
+
+    private var bookManagementService: (any BookManagementService)?
+
+    func configure(bookManagementService: any BookManagementService) {
+        guard self.bookManagementService == nil else { return }
+        self.bookManagementService = bookManagementService
+    }
+
+    func preloadPages(userBook: FGUserBook, adjustedToday: Date) {
+        guard let readingRecord = userBook.readingProgress.getDailyReadingRecord(for: adjustedToday) else { return }
+        pagesToReadToday = readingRecord.targetPages
+    }
+
+    func requestSubmit(targetEndPage: Int) -> Bool {
+        if pagesToReadToday > targetEndPage {
+            showTargetExceededAlert = true
+            return false
+        }
+        return true
+    }
+
+    func applyMaximumTargetPages(_ targetEndPage: Int) {
+        pagesToReadToday = targetEndPage
+    }
+
+    func submit(bookId: UUID, readDate: Date) async -> SubmitOutcome {
+        guard !isSubmitting else { return .none }
+        guard let bookManagementService else { return .none }
+
+        isSubmitting = true
+        let pagesRead = pagesToReadToday
+        defer { isSubmitting = false }
+
+        do {
+            let result = try await bookManagementService.recordReading(
+                bookId: bookId,
+                pagesRead: pagesRead,
+                readDate: readDate
+            )
+
+            switch result {
+            case .recorded, .dateExtended:
+                return .popToRoot
+            case .completed(let updatedBook):
+                return .completionCelebration(book: updatedBook)
+            case .exceedsTarget:
+                showTargetExceededAlert = true
+                return .none
+            }
+        } catch {
+            print("독서 기록 저장 중 오류 발생: \(error.localizedDescription)")
+            return .none
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/FinishGoalViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/FinishGoalViewModel.swift
@@ -1,0 +1,87 @@
+//
+//  FinishGoalViewModel.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class FinishGoalViewModel {
+    var pagesPerDay = 0
+    private(set) var isSubmitting = false
+
+    private var bookManagementService: (any BookManagementService)?
+
+    func configure(bookManagementService: any BookManagementService) {
+        guard self.bookManagementService == nil else { return }
+        self.bookManagementService = bookManagementService
+    }
+
+    func calculateRecommendedPagesPerDay(
+        startPage: Int,
+        targetEndPage: Int,
+        startDate: Date,
+        endDate: Date,
+        excludedDays: [Date]
+    ) {
+        let totalDays = try? ReadingDateCalculator().calculateValidReadingDays(
+            startDate: startDate,
+            endDate: endDate,
+            excludedDates: excludedDays
+        )
+
+        guard let totalDays, totalDays > 0 else {
+            pagesPerDay = 0
+            return
+        }
+
+        pagesPerDay = ReadingPagesCalculator().calculatePagesPerDayAndRemainder(
+            totalDays: totalDays,
+            startPage: startPage,
+            endPage: targetEndPage
+        ).pagesPerDay
+    }
+
+    func registerBook(
+        selectedBook: Book,
+        startPage: Int,
+        targetEndPage: Int,
+        startDate: Date,
+        endDate: Date,
+        excludedReadingDays: [Date]
+    ) async -> Bool {
+        guard !isSubmitting else { return false }
+        guard let bookManagementService else { return false }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        let input = RegisterBookInput(
+            bookMetaData: FGBookMetaData(
+                title: selectedBook.title,
+                author: selectedBook.author,
+                coverImageURL: selectedBook.cover,
+                totalPages: targetEndPage
+            ),
+            userSettings: FGUserSetting(
+                startPage: startPage,
+                targetEndPage: targetEndPage,
+                startDate: startDate,
+                targetEndDate: endDate,
+                excludedReadingDays: excludedReadingDays
+            )
+        )
+
+        do {
+            _ = try await bookManagementService.registerBook(input)
+            return true
+        } catch {
+            print("책 등록 중 오류 발생: \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NotiSettingViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NotiSettingViewModel.swift
@@ -97,10 +97,9 @@ final class NotiSettingViewModel {
     func handleNotificationStatusChange(userBook: FGUserBook?) {
         notificationStatusTask?.cancel()
         let isDisabled = isNotificationDisabled
+        settingsStore.saveNotificationDisabled(isDisabled)
 
         notificationStatusTask = Task {
-            settingsStore.saveNotificationDisabled(isDisabled)
-
             guard let userBook else { return }
             guard !Task.isCancelled else { return }
 
@@ -115,10 +114,9 @@ final class NotiSettingViewModel {
     func handleNotificationTimeChange(userBook: FGUserBook?) {
         notificationTimeTask?.cancel()
         let currentSelectedTime = selectedTime
+        saveNotificationTime(currentSelectedTime)
 
         notificationTimeTask = Task {
-            saveNotificationTime(currentSelectedTime)
-
             guard let userBook else { return }
             guard !Task.isCancelled else { return }
 

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NotiSettingViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NotiSettingViewModel.swift
@@ -1,0 +1,137 @@
+//
+//  NotiSettingViewModel.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+import Foundation
+import Observation
+
+protocol NotificationManaging {
+    func requestAuthorization() async -> Bool
+    func clearRequests() async
+    func setupAllNotifications(_ readingBook: FGUserBook) async
+    func updateNotification(notificationType: NotificationType) async
+}
+
+extension NotificationManager: NotificationManaging {}
+
+protocol NotificationSettingsStoring {
+    func saveNotificationDisabled(_ isNotificationDisabled: Bool)
+    func fetchNotificationDisabled() -> Bool
+    func saveNotificationTime(hour: Int, minute: Int)
+    func fetchNotificationReminderTime() -> (hour: Int, minute: Int)
+}
+
+struct UserDefaultsNotificationSettingsStore: NotificationSettingsStoring {
+    func saveNotificationDisabled(_ isNotificationDisabled: Bool) {
+        UserDefaultsManager.saveNotificationDisabled(isNotificationDisabled)
+    }
+
+    func fetchNotificationDisabled() -> Bool {
+        UserDefaultsManager.fetchNotificationDisabled()
+    }
+
+    func saveNotificationTime(hour: Int, minute: Int) {
+        UserDefaultsManager.saveNotificationTime(hour: hour, minute: minute)
+    }
+
+    func fetchNotificationReminderTime() -> (hour: Int, minute: Int) {
+        UserDefaultsManager.fetchNotificationReminderTime()
+    }
+}
+
+@MainActor
+@Observable
+final class NotiSettingViewModel {
+    var selectedTime: Date = Date()
+    var isNotificationDisabled = false
+    var isReminderTimePickerVisible = false
+    var isSystemNotificationEnabled = true
+
+    private var notificationStatusTask: Task<Void, Never>?
+    private var notificationTimeTask: Task<Void, Never>?
+
+    private let notificationManager: any NotificationManaging
+    private let settingsStore: any NotificationSettingsStoring
+    private let nowProvider: () -> Date
+
+    init(
+        notificationManager: any NotificationManaging = NotificationManager(),
+        settingsStore: any NotificationSettingsStoring = UserDefaultsNotificationSettingsStore(),
+        nowProvider: @escaping () -> Date = Date.init
+    ) {
+        self.notificationManager = notificationManager
+        self.settingsStore = settingsStore
+        self.nowProvider = nowProvider
+    }
+
+    var timeSelectionRange: ClosedRange<Date> {
+        let calendar = Calendar.app
+        let now = nowProvider()
+        let startOfDay = calendar.startOfDay(for: now)
+        let start = calendar.date(bySettingHour: 4, minute: 0, second: 0, of: startOfDay) ?? now
+        let end = calendar.date(bySettingHour: 23, minute: 55, second: 0, of: startOfDay) ?? now
+        return start...end
+    }
+
+    func loadPersistedSettings() {
+        let calendar = Calendar.app
+        let (hour, minute) = settingsStore.fetchNotificationReminderTime()
+
+        selectedTime = calendar.date(
+            bySettingHour: hour,
+            minute: minute,
+            second: 0,
+            of: nowProvider()
+        ) ?? nowProvider()
+
+        isNotificationDisabled = settingsStore.fetchNotificationDisabled()
+    }
+
+    func refreshSystemNotificationAuthorization() async {
+        isSystemNotificationEnabled = await notificationManager.requestAuthorization()
+    }
+
+    func handleNotificationStatusChange(userBook: FGUserBook?) {
+        notificationStatusTask?.cancel()
+        let isDisabled = isNotificationDisabled
+
+        notificationStatusTask = Task {
+            settingsStore.saveNotificationDisabled(isDisabled)
+
+            guard let userBook else { return }
+            guard !Task.isCancelled else { return }
+
+            if isDisabled {
+                await notificationManager.clearRequests()
+            } else {
+                await notificationManager.setupAllNotifications(userBook)
+            }
+        }
+    }
+
+    func handleNotificationTimeChange(userBook: FGUserBook?) {
+        notificationTimeTask?.cancel()
+        let currentSelectedTime = selectedTime
+
+        notificationTimeTask = Task {
+            saveNotificationTime(currentSelectedTime)
+
+            guard let userBook else { return }
+            guard !Task.isCancelled else { return }
+
+            await notificationManager.updateNotification(
+                notificationType: .morning(readingBook: userBook)
+            )
+        }
+    }
+
+    private func saveNotificationTime(_ time: Date) {
+        let calendar = Calendar.app
+        let hour = calendar.component(.hour, from: time)
+        let minute = calendar.component(.minute, from: time)
+        settingsStore.saveNotificationTime(hour: hour, minute: minute)
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/ReadingDateEditViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/ReadingDateEditViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  ReadingDateEditViewModel.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ReadingDateEditViewModel {
+    private(set) var isSubmitting = false
+
+    private var bookManagementService: (any BookManagementService)?
+
+    func configure(bookManagementService: any BookManagementService) {
+        guard self.bookManagementService == nil else { return }
+        self.bookManagementService = bookManagementService
+    }
+
+    func submitReadingPlanUpdate(
+        bookId: UUID,
+        startDate: Date,
+        endDate: Date,
+        excludedReadingDays: [Date],
+        today: Date
+    ) async -> Bool {
+        guard !isSubmitting else { return false }
+        guard let bookManagementService else { return false }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        do {
+            try await bookManagementService.updateReadingPlan(
+                bookId: bookId,
+                startDate: startDate,
+                targetEndDate: endDate,
+                excludedReadingDays: excludedReadingDays,
+                today: today
+            )
+            return true
+        } catch {
+            print("목표기간 수정 저장 중 오류 발생: \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/UnfinishReadingViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/UnfinishReadingViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  UnfinishReadingViewModel.swift
+//  FiveGuyes
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+import Observation
+
+@MainActor
+@Observable
+final class UnfinishReadingViewModel {
+    private(set) var isCompleting = false
+
+    private var bookManagementService: (any BookManagementService)?
+
+    func configure(bookManagementService: any BookManagementService) {
+        guard self.bookManagementService == nil else { return }
+        self.bookManagementService = bookManagementService
+    }
+
+    func completeBook(_ userBook: FGUserBook) async -> Bool {
+        guard !isCompleting else { return false }
+        guard let bookManagementService else { return false }
+
+        isCompleting = true
+        defer { isCompleting = false }
+
+        do {
+            try await bookManagementService.completeBook(
+                id: userBook.id,
+                completionDate: userBook.userSettings.targetEndDate,
+                review: ""
+            )
+            return true
+        } catch {
+            print("미완독 종료 처리 중 오류 발생: \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/FiveGuyes/FiveGuyesTests/PresentationViewModelTests.swift
+++ b/FiveGuyes/FiveGuyesTests/PresentationViewModelTests.swift
@@ -1,0 +1,745 @@
+//
+//  PresentationViewModelTests.swift
+//  FiveGuyesTests
+//
+//  Created by zaehorang on 2/13/26.
+//
+
+@testable import FiveGuyes
+import Foundation
+import Testing
+
+@Suite("Presentation ViewModel 테스트")
+@MainActor
+struct PresentationViewModelTests {
+    @Test("DailyProgressViewModel: 목표 초과 입력 시 제출 차단")
+    func dailyProgress_overTarget_preventsSubmit() {
+        let viewModel = DailyProgressViewModel()
+        viewModel.pagesToReadToday = 101
+
+        let canSubmit = viewModel.requestSubmit(targetEndPage: 100)
+
+        #expect(!canSubmit)
+        #expect(viewModel.showTargetExceededAlert)
+    }
+
+    @Test("DailyProgressViewModel: 완독 결과일 때 완독 화면 이동 결과 반환")
+    func dailyProgress_completedOutcome() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.recordReadingResult = .completed(updatedBook: book)
+
+        let viewModel = DailyProgressViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.pagesToReadToday = 300
+
+        let outcome = await viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
+
+        switch outcome {
+        case .completionCelebration(let updatedBook):
+            #expect(updatedBook.id == book.id)
+        default:
+            Issue.record("Expected .completionCelebration, got \(outcome)")
+        }
+        #expect(service.recordReadingCallCount == 1)
+        #expect(!viewModel.isSubmitting)
+    }
+
+    @Test("DailyProgressViewModel: 실패 시 none 반환 및 submitting 해제")
+    func dailyProgress_failure_returnsNone() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.recordReadingError = TestError.forced
+
+        let viewModel = DailyProgressViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.pagesToReadToday = 120
+
+        let outcome = await viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
+
+        if case .none = outcome {
+            #expect(service.recordReadingCallCount == 1)
+            #expect(!viewModel.isSubmitting)
+        } else {
+            Issue.record("Expected .none on failure")
+        }
+    }
+
+    @Test("DailyProgressViewModel: 중복 제출 시 두 번째 요청 무시")
+    func dailyProgress_duplicateSubmit_ignored() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.recordReadingDelayNanoseconds = 80_000_000
+        service.recordReadingResult = .recorded(updatedBook: book)
+
+        let viewModel = DailyProgressViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.pagesToReadToday = 10
+
+        async let first = viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
+        await Task.yield()
+        let second = await viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
+        _ = await first
+
+        if case .none = second {
+            #expect(service.recordReadingCallCount == 1)
+        } else {
+            Issue.record("Expected second submit to return .none while submitting")
+        }
+    }
+
+    @Test("CompletionReviewViewModel: 빈 입력이면 경고 표시")
+    func completionReview_emptyReview_showsAlert() async {
+        let service = BookManagementServiceStub()
+        let viewModel = CompletionReviewViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.preloadReview("   ")
+
+        let outcome = await viewModel.submit(
+            userBookId: UUID(),
+            isUpdateMode: false,
+            completionDate: makeDate("2025-01-10")
+        )
+
+        if case .none = outcome {
+            #expect(viewModel.showEmptyReviewAlert)
+        } else {
+            Issue.record("Expected .none for empty review")
+        }
+        #expect(service.completeBookCallCount == 0)
+    }
+
+    @Test("CompletionReviewViewModel: 수정 모드에서 updateCompletionReview 호출")
+    func completionReview_updateMode_callsUpdateCommand() async {
+        let book = makeBook(isCompleted: true)
+        let service = BookManagementServiceStub(book: book)
+        let viewModel = CompletionReviewViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.preloadReview("수정된 소감")
+
+        let outcome = await viewModel.submit(
+            userBookId: book.id,
+            isUpdateMode: true,
+            completionDate: makeDate("2025-01-10")
+        )
+
+        if case .popToRoot = outcome {
+            #expect(service.updateCompletionReviewCallCount == 1)
+            #expect(service.completeBookCallCount == 0)
+        } else {
+            Issue.record("Expected .popToRoot for update mode")
+        }
+    }
+
+    @Test("CompletionReviewViewModel: 저장 실패 시 none 반환")
+    func completionReview_failure_returnsNone() async {
+        let book = makeBook(isCompleted: false)
+        let service = BookManagementServiceStub(book: book)
+        service.completeBookError = TestError.forced
+
+        let viewModel = CompletionReviewViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.preloadReview("완독 소감")
+
+        let outcome = await viewModel.submit(
+            userBookId: book.id,
+            isUpdateMode: false,
+            completionDate: makeDate("2025-01-10")
+        )
+
+        if case .none = outcome {
+            #expect(service.completeBookCallCount == 1)
+            #expect(!viewModel.isSubmitting)
+        } else {
+            Issue.record("Expected .none on completion review failure")
+        }
+    }
+
+    @Test("CompletionReviewViewModel: 중복 제출 시 두 번째 요청 무시")
+    func completionReview_duplicateSubmit_ignored() async {
+        let book = makeBook(isCompleted: false)
+        let service = BookManagementServiceStub(book: book)
+        service.completeBookDelayNanoseconds = 80_000_000
+
+        let viewModel = CompletionReviewViewModel()
+        viewModel.configure(bookManagementService: service)
+        viewModel.preloadReview("완독 소감")
+
+        async let first = viewModel.submit(
+            userBookId: book.id,
+            isUpdateMode: false,
+            completionDate: makeDate("2025-01-10")
+        )
+        await Task.yield()
+        let second = await viewModel.submit(
+            userBookId: book.id,
+            isUpdateMode: false,
+            completionDate: makeDate("2025-01-10")
+        )
+        _ = await first
+
+        if case .none = second {
+            #expect(service.completeBookCallCount == 1)
+        } else {
+            Issue.record("Expected second submit to return .none while submitting")
+        }
+    }
+
+    @Test("ReadingDateEditViewModel: updateReadingPlan 성공 시 true 반환")
+    func readingDateEdit_success() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        let viewModel = ReadingDateEditViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let isUpdated = await viewModel.submitReadingPlanUpdate(
+            bookId: book.id,
+            startDate: makeDate("2025-01-01"),
+            endDate: makeDate("2025-01-31"),
+            excludedReadingDays: [],
+            today: makeDate("2025-01-02")
+        )
+
+        #expect(isUpdated)
+        #expect(service.updateReadingPlanCallCount == 1)
+    }
+
+    @Test("ReadingDateEditViewModel: 실패 시 false 반환")
+    func readingDateEdit_failure() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.updateReadingPlanError = TestError.forced
+        let viewModel = ReadingDateEditViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let isUpdated = await viewModel.submitReadingPlanUpdate(
+            bookId: book.id,
+            startDate: makeDate("2025-01-01"),
+            endDate: makeDate("2025-01-31"),
+            excludedReadingDays: [],
+            today: makeDate("2025-01-02")
+        )
+
+        #expect(!isUpdated)
+        #expect(service.updateReadingPlanCallCount == 1)
+    }
+
+    @Test("ReadingDateEditViewModel: 중복 제출 시 두 번째 요청 무시")
+    func readingDateEdit_duplicateSubmit_ignored() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.updateReadingPlanDelayNanoseconds = 200_000_000
+
+        let viewModel = ReadingDateEditViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let firstTask = Task {
+            await viewModel.submitReadingPlanUpdate(
+                bookId: book.id,
+                startDate: makeDate("2025-01-01"),
+                endDate: makeDate("2025-01-31"),
+                excludedReadingDays: [],
+                today: makeDate("2025-01-02")
+            )
+        }
+        for _ in 0..<20 where service.updateReadingPlanCallCount == 0 {
+            await Task.yield()
+        }
+        let second = await viewModel.submitReadingPlanUpdate(
+            bookId: book.id,
+            startDate: makeDate("2025-01-01"),
+            endDate: makeDate("2025-01-31"),
+            excludedReadingDays: [],
+            today: makeDate("2025-01-02")
+        )
+        _ = await firstTask.value
+
+        #expect(!second)
+        #expect(service.updateReadingPlanCallCount == 1)
+    }
+
+    @Test("FinishGoalViewModel: registerBook 성공 시 true 반환")
+    func finishGoal_registerBook_success() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        let viewModel = FinishGoalViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let apiBook = Book(
+            title: "테스트 도서",
+            author: "작가",
+            cover: nil,
+            publisher: "출판사",
+            isbn13: "1234567890123",
+            pubDate: "20250101"
+        )
+
+        let isRegistered = await viewModel.registerBook(
+            selectedBook: apiBook,
+            startPage: 1,
+            targetEndPage: 300,
+            startDate: makeDate("2025-01-01"),
+            endDate: makeDate("2025-01-31"),
+            excludedReadingDays: []
+        )
+
+        #expect(isRegistered)
+        #expect(service.registerBookCallCount == 1)
+    }
+
+    @Test("FinishGoalViewModel: 등록 실패 시 false 반환")
+    func finishGoal_registerBook_failure() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.registerBookError = TestError.forced
+        let viewModel = FinishGoalViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let apiBook = Book(
+            title: "테스트 도서",
+            author: "작가",
+            cover: nil,
+            publisher: "출판사",
+            isbn13: "1234567890123",
+            pubDate: "20250101"
+        )
+
+        let isRegistered = await viewModel.registerBook(
+            selectedBook: apiBook,
+            startPage: 1,
+            targetEndPage: 300,
+            startDate: makeDate("2025-01-01"),
+            endDate: makeDate("2025-01-31"),
+            excludedReadingDays: []
+        )
+
+        #expect(!isRegistered)
+        #expect(service.registerBookCallCount == 1)
+    }
+
+    @Test("FinishGoalViewModel: 중복 등록 시 두 번째 요청 무시")
+    func finishGoal_registerBook_duplicateSubmit_ignored() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.registerBookDelayNanoseconds = 200_000_000
+        let viewModel = FinishGoalViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let apiBook = Book(
+            title: "테스트 도서",
+            author: "작가",
+            cover: nil,
+            publisher: "출판사",
+            isbn13: "1234567890123",
+            pubDate: "20250101"
+        )
+
+        let firstTask = Task {
+            await viewModel.registerBook(
+                selectedBook: apiBook,
+                startPage: 1,
+                targetEndPage: 300,
+                startDate: makeDate("2025-01-01"),
+                endDate: makeDate("2025-01-31"),
+                excludedReadingDays: []
+            )
+        }
+        for _ in 0..<20 where service.registerBookCallCount == 0 {
+            await Task.yield()
+        }
+        let second = await viewModel.registerBook(
+            selectedBook: apiBook,
+            startPage: 1,
+            targetEndPage: 300,
+            startDate: makeDate("2025-01-01"),
+            endDate: makeDate("2025-01-31"),
+            excludedReadingDays: []
+        )
+        _ = await firstTask.value
+
+        #expect(!second)
+        #expect(service.registerBookCallCount == 1)
+    }
+
+    @Test("UnfinishReadingViewModel: completeBook 성공 시 true 반환")
+    func unfinishReading_completeBook_success() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        let viewModel = UnfinishReadingViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let completed = await viewModel.completeBook(book)
+
+        #expect(completed)
+        #expect(service.completeBookCallCount == 1)
+    }
+
+    @Test("UnfinishReadingViewModel: 실패 시 false 반환")
+    func unfinishReading_completeBook_failure() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.completeBookError = TestError.forced
+        let viewModel = UnfinishReadingViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        let completed = await viewModel.completeBook(book)
+
+        #expect(!completed)
+        #expect(service.completeBookCallCount == 1)
+    }
+
+    @Test("UnfinishReadingViewModel: 중복 완료 요청 시 두 번째 요청 무시")
+    func unfinishReading_duplicateSubmit_ignored() async {
+        let book = makeBook()
+        let service = BookManagementServiceStub(book: book)
+        service.completeBookDelayNanoseconds = 80_000_000
+        let viewModel = UnfinishReadingViewModel()
+        viewModel.configure(bookManagementService: service)
+
+        async let first = viewModel.completeBook(book)
+        await Task.yield()
+        let second = await viewModel.completeBook(book)
+        _ = await first
+
+        #expect(!second)
+        #expect(service.completeBookCallCount == 1)
+    }
+
+    @Test("NotiSettingViewModel: 저장된 설정 로드")
+    func notiSetting_loadPersistedSettings() {
+        let notificationManager = NotificationManagerStub()
+        let settingsStore = NotificationSettingsStoreStub(
+            disabled: true,
+            reminderHour: 8,
+            reminderMinute: 30
+        )
+        let viewModel = NotiSettingViewModel(
+            notificationManager: notificationManager,
+            settingsStore: settingsStore,
+            nowProvider: { self.makeDate("2025-01-01") }
+        )
+
+        viewModel.loadPersistedSettings()
+
+        #expect(viewModel.isNotificationDisabled)
+        let timeComponents = Calendar.app.dateComponents([.hour, .minute], from: viewModel.selectedTime)
+        #expect(timeComponents.hour == 8)
+        #expect(timeComponents.minute == 30)
+    }
+
+    @Test("NotiSettingViewModel: 알림 비활성화 시 요청 삭제 호출")
+    func notiSetting_disable_clearsRequests() async {
+        let notificationManager = NotificationManagerStub()
+        let settingsStore = NotificationSettingsStoreStub(
+            disabled: false,
+            reminderHour: 9,
+            reminderMinute: 0
+        )
+        let viewModel = NotiSettingViewModel(
+            notificationManager: notificationManager,
+            settingsStore: settingsStore
+        )
+
+        viewModel.isNotificationDisabled = true
+        viewModel.handleNotificationStatusChange(userBook: makeBook())
+
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(settingsStore.savedNotificationDisabled == true)
+        #expect(notificationManager.clearRequestsCallCount == 1)
+        #expect(notificationManager.setupAllNotificationsCallCount == 0)
+    }
+
+    @Test("NotiSettingViewModel: 시간 변경 시 설정 저장 및 알림 업데이트")
+    func notiSetting_timeChange_updatesSettingsAndNotification() async {
+        let notificationManager = NotificationManagerStub()
+        let settingsStore = NotificationSettingsStoreStub(
+            disabled: false,
+            reminderHour: 7,
+            reminderMinute: 0
+        )
+        let viewModel = NotiSettingViewModel(
+            notificationManager: notificationManager,
+            settingsStore: settingsStore,
+            nowProvider: { self.makeDate("2025-01-01") }
+        )
+
+        let baseDate = makeDate("2025-01-01")
+        viewModel.selectedTime = Calendar.app.date(
+            bySettingHour: 21,
+            minute: 15,
+            second: 0,
+            of: baseDate
+        ) ?? baseDate
+        viewModel.handleNotificationTimeChange(userBook: makeBook())
+
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(settingsStore.savedReminderHour == 21)
+        #expect(settingsStore.savedReminderMinute == 15)
+        #expect(notificationManager.updateNotificationCallCount == 1)
+    }
+
+    @Test("NotiSettingViewModel: 빠른 연속 시간 변경 시 마지막 요청만 처리")
+    func notiSetting_timeChange_cancelsPreviousTask() async {
+        let notificationManager = NotificationManagerStub()
+        notificationManager.updateNotificationDelayNanoseconds = 80_000_000
+        notificationManager.ignoreCancelledCalls = true
+
+        let settingsStore = NotificationSettingsStoreStub(
+            disabled: false,
+            reminderHour: 7,
+            reminderMinute: 0
+        )
+        let viewModel = NotiSettingViewModel(
+            notificationManager: notificationManager,
+            settingsStore: settingsStore,
+            nowProvider: { self.makeDate("2025-01-01") }
+        )
+
+        let baseDate = makeDate("2025-01-01")
+        let firstTime = Calendar.app.date(bySettingHour: 8, minute: 10, second: 0, of: baseDate) ?? baseDate
+        let secondTime = Calendar.app.date(bySettingHour: 9, minute: 20, second: 0, of: baseDate) ?? baseDate
+
+        viewModel.selectedTime = firstTime
+        viewModel.handleNotificationTimeChange(userBook: makeBook())
+        viewModel.selectedTime = secondTime
+        viewModel.handleNotificationTimeChange(userBook: makeBook())
+
+        try? await Task.sleep(nanoseconds: 140_000_000)
+
+        #expect(settingsStore.savedReminderHour == 9)
+        #expect(settingsStore.savedReminderMinute == 20)
+        #expect(notificationManager.updateNotificationCallCount == 1)
+    }
+
+    private func makeBook(id: UUID = UUID(), isCompleted: Bool = false) -> FGUserBook {
+        FGUserBook(
+            id: id,
+            bookMetaData: FGBookMetaData(
+                title: "테스트 책",
+                author: "테스트 작가",
+                coverImageURL: nil,
+                totalPages: 300
+            ),
+            userSettings: FGUserSetting(
+                startPage: 1,
+                targetEndPage: 300,
+                startDate: makeDate("2025-01-01"),
+                targetEndDate: makeDate("2025-01-31"),
+                excludedReadingDays: []
+            ),
+            readingProgress: FGReadingProgress(
+                dailyReadingRecords: [:],
+                lastReadDate: nil,
+                lastReadPage: 0
+            ),
+            completionStatus: FGCompletionStatus(
+                isCompleted: isCompleted,
+                reviewAfterCompletion: ""
+            )
+        )
+    }
+
+    private func makeDate(_ dateString: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = Calendar.app.timeZone
+        guard let date = formatter.date(from: dateString) else {
+            fatalError("Invalid date string: \(dateString)")
+        }
+        return date.onlyDate
+    }
+}
+
+private enum TestError: Error {
+    case forced
+}
+
+private final class BookManagementServiceStub: BookManagementService {
+    var registerBookResult: FGUserBook
+    var recordReadingResult: RecordReadingResult
+    var fetchReadingBooksResult: [FGUserBook]
+    var fetchCompletedBooksResult: [FGUserBook]
+    var fetchBookDetailResult: FGUserBook
+
+    var registerBookError: Error?
+    var recordReadingError: Error?
+    var deleteBookError: Error?
+    var completeBookError: Error?
+    var updateCompletionReviewError: Error?
+    var updateReadingPlanError: Error?
+    var fetchReadingBooksError: Error?
+    var fetchCompletedBooksError: Error?
+    var fetchBookDetailError: Error?
+    var rescheduleOnAppOpenError: Error?
+
+    var registerBookDelayNanoseconds: UInt64 = 0
+    var recordReadingDelayNanoseconds: UInt64 = 0
+    var completeBookDelayNanoseconds: UInt64 = 0
+    var updateCompletionReviewDelayNanoseconds: UInt64 = 0
+    var updateReadingPlanDelayNanoseconds: UInt64 = 0
+
+    var registerBookCallCount = 0
+    var recordReadingCallCount = 0
+    var deleteBookCallCount = 0
+    var completeBookCallCount = 0
+    var updateCompletionReviewCallCount = 0
+    var updateReadingPlanCallCount = 0
+    var fetchReadingBooksCallCount = 0
+    var fetchCompletedBooksCallCount = 0
+    var fetchBookDetailCallCount = 0
+    var rescheduleOnAppOpenCallCount = 0
+
+    init(book: FGUserBook = .dummy) {
+        self.registerBookResult = book
+        self.recordReadingResult = .recorded(updatedBook: book)
+        self.fetchReadingBooksResult = [book]
+        self.fetchCompletedBooksResult = []
+        self.fetchBookDetailResult = book
+    }
+
+    func registerBook(_ input: RegisterBookInput) async throws -> FGUserBook {
+        registerBookCallCount += 1
+        if registerBookDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: registerBookDelayNanoseconds)
+        }
+        if let registerBookError { throw registerBookError }
+        return registerBookResult
+    }
+
+    func recordReading(bookId: UUID, pagesRead: Int, readDate: Date) async throws -> RecordReadingResult {
+        recordReadingCallCount += 1
+        if recordReadingDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: recordReadingDelayNanoseconds)
+        }
+        if let recordReadingError { throw recordReadingError }
+        return recordReadingResult
+    }
+
+    func deleteBook(id: UUID) async throws {
+        deleteBookCallCount += 1
+        if let deleteBookError { throw deleteBookError }
+    }
+
+    func completeBook(id: UUID, completionDate: Date, review: String) async throws {
+        completeBookCallCount += 1
+        if completeBookDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: completeBookDelayNanoseconds)
+        }
+        if let completeBookError { throw completeBookError }
+    }
+
+    func updateCompletionReview(id: UUID, review: String) async throws {
+        updateCompletionReviewCallCount += 1
+        if updateCompletionReviewDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: updateCompletionReviewDelayNanoseconds)
+        }
+        if let updateCompletionReviewError { throw updateCompletionReviewError }
+    }
+
+    func updateReadingPlan(
+        bookId: UUID,
+        startDate: Date,
+        targetEndDate: Date,
+        excludedReadingDays: [Date],
+        today: Date
+    ) async throws {
+        updateReadingPlanCallCount += 1
+        if updateReadingPlanDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: updateReadingPlanDelayNanoseconds)
+        }
+        if let updateReadingPlanError { throw updateReadingPlanError }
+    }
+
+    func fetchReadingBooks() async throws -> [FGUserBook] {
+        fetchReadingBooksCallCount += 1
+        if let fetchReadingBooksError { throw fetchReadingBooksError }
+        return fetchReadingBooksResult
+    }
+
+    func fetchCompletedBooks() async throws -> [FGUserBook] {
+        fetchCompletedBooksCallCount += 1
+        if let fetchCompletedBooksError { throw fetchCompletedBooksError }
+        return fetchCompletedBooksResult
+    }
+
+    func fetchBookDetail(id: UUID) async throws -> FGUserBook {
+        fetchBookDetailCallCount += 1
+        if let fetchBookDetailError { throw fetchBookDetailError }
+        return fetchBookDetailResult
+    }
+
+    func rescheduleOnAppOpen(bookId: UUID, today: Date) async throws {
+        rescheduleOnAppOpenCallCount += 1
+        if let rescheduleOnAppOpenError { throw rescheduleOnAppOpenError }
+    }
+}
+
+private final class NotificationManagerStub: NotificationManaging {
+    var isAuthorized = true
+    var requestAuthorizationCallCount = 0
+    var clearRequestsCallCount = 0
+    var setupAllNotificationsCallCount = 0
+    var updateNotificationCallCount = 0
+    var updateNotificationDelayNanoseconds: UInt64 = 0
+    var ignoreCancelledCalls = false
+
+    func requestAuthorization() async -> Bool {
+        requestAuthorizationCallCount += 1
+        return isAuthorized
+    }
+
+    func clearRequests() async {
+        clearRequestsCallCount += 1
+    }
+
+    func setupAllNotifications(_ readingBook: FGUserBook) async {
+        setupAllNotificationsCallCount += 1
+    }
+
+    func updateNotification(notificationType: NotificationType) async {
+        if updateNotificationDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: updateNotificationDelayNanoseconds)
+        }
+        if ignoreCancelledCalls && Task.isCancelled {
+            return
+        }
+        updateNotificationCallCount += 1
+    }
+}
+
+private final class NotificationSettingsStoreStub: NotificationSettingsStoring {
+    private let storedDisabled: Bool
+    private let storedReminderHour: Int
+    private let storedReminderMinute: Int
+
+    var savedNotificationDisabled: Bool?
+    var savedReminderHour: Int?
+    var savedReminderMinute: Int?
+
+    init(disabled: Bool, reminderHour: Int, reminderMinute: Int) {
+        self.storedDisabled = disabled
+        self.storedReminderHour = reminderHour
+        self.storedReminderMinute = reminderMinute
+    }
+
+    func saveNotificationDisabled(_ isNotificationDisabled: Bool) {
+        savedNotificationDisabled = isNotificationDisabled
+    }
+
+    func fetchNotificationDisabled() -> Bool {
+        storedDisabled
+    }
+
+    func saveNotificationTime(hour: Int, minute: Int) {
+        savedReminderHour = hour
+        savedReminderMinute = minute
+    }
+
+    func fetchNotificationReminderTime() -> (hour: Int, minute: Int) {
+        (storedReminderHour, storedReminderMinute)
+    }
+}

--- a/docs/execplans/mvvm-architecture-refactoring-execplan.md
+++ b/docs/execplans/mvvm-architecture-refactoring-execplan.md
@@ -25,6 +25,11 @@ The change is observable when the core screens still behave the same in the simu
 - [x] (2026-02-12 13:40Z) Revalidated full test suite after query/payload refactor (`xcodebuild test` -> `** TEST SUCCEEDED **`).
 - [x] (2026-02-12 13:44Z) Decoupled notification flow from SwiftData payload (`NotiSettingView`, `NotificationManager`, `NotificationType` now use `FGUserBook`; added `FGReadingProgress+Notification` helper extension).
 - [x] (2026-02-12 13:44Z) Revalidated full test suite after notification decoupling (`xcodebuild test` -> `** TEST SUCCEEDED **`).
+- [x] (2026-02-13 01:10) Verified post-merge baseline on `develop`: working tree clean, presentation boundary check (`@Query`, `modelContext`, `ReadingScheduleCalculator(`) returns no active runtime violations, full `xcodebuild test` passes on iPhone 17 simulator.
+- [x] (2026-02-13 01:24) Extracted remaining service-calling screens (`DailyProgress`, `CompletionReview`, `ReadingDateEdit`, `FinishGoal`, `UnfinishReading`) into feature ViewModels so Views stop owning async command flow/state transitions.
+- [x] (2026-02-13 01:26) Introduced notification settings ViewModel and abstraction seam (`NotiSettingViewModel`, `NotificationManaging`, `NotificationSettingsStoring`) so `NotiSettingView` no longer directly coordinates `NotificationManager`/`UserDefaultsManager`.
+- [x] (2026-02-13 01:28) Added ViewModel-focused tests in `FiveGuyesTests/PresentationViewModelTests.swift` for new action/state paths (daily progress, completion review, date edit, finish goal, unfinish flow, notification settings).
+- [x] (2026-02-13 01:30) Revalidated full test suite (`xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"` -> `** TEST SUCCEEDED **`).
 
 ## Surprises & Discoveries
 
@@ -45,6 +50,12 @@ The change is observable when the core screens still behave the same in the simu
 
 - Observation: Notification decoupling required moving "next reading day/pages" helper behavior from SwiftData model APIs to domain extension APIs.
   Evidence: Added `FGReadingProgress+Notification.swift` and switched `NotificationManager`/`NotificationType` inputs to `FGUserBook`.
+
+- Observation: Presentation boundary hardening succeeded, but action/state orchestration is still concentrated in several Views and not yet covered by dedicated ViewModel tests.
+  Evidence: `DailyProgressView`, `CompletionReviewView`, `FinishGoalView`, `ReadingDateEditView`, `UnfinishReadingView`, `NotiSettingView` still own async action handlers and local submit/task guards; test target currently covers calculators/services/repository only.
+
+- Observation: `@Bindable` local bindings inside computed `some View` properties can require explicit `return` when additional local declarations are present.
+  Evidence: `NotiSettingView.timePicker` needed explicit `return VStack { ... }` after introducing `@Bindable var bindableViewModel`.
 
 ## Decision Log
 
@@ -80,6 +91,14 @@ The change is observable when the core screens still behave the same in the simu
   Rationale: This removes the last presentation-level SwiftData dependency without reintroducing persistence coupling into UI flows.
   Date/Author: 2026-02-12 / Codex
 
+- Decision: Start Phase 2 with "feature ViewModel extraction + ViewModel tests" instead of broad architecture replacement.
+  Rationale: ADR-0001 selected incremental MVVM migration; the highest remaining risk is untested action orchestration in Views, not missing persistence boundaries.
+  Date/Author: 2026-02-13 / Codex
+
+- Decision: Introduce thin protocol seams for notification dependencies (`NotificationManaging`, `NotificationSettingsStoring`) in Presentation ViewModel layer.
+  Rationale: Noti 설정 흐름의 비동기 상태 전이를 ViewModel 단위에서 테스트하기 위해, 시스템/저장소 호출을 최소 추상화로 분리했다.
+  Date/Author: 2026-02-13 / Codex
+
 ## Outcomes & Retrospective
 
 Current outcome: composition root wiring is in place (`AppDependencies` injected at app root), and core write paths in reading/registration/completion/date-edit flows now route through domain service boundaries:
@@ -93,7 +112,9 @@ Current outcome: composition root wiring is in place (`AppDependencies` injected
 - `ReadingDateEditView` -> `BookManagementService.updateReadingPlan`
 - `CompletedBooksView` delete flow -> `BookManagementService.deleteBook`
 
-Behavioral parity was validated through repeated `xcodebuild test` runs on iPhone 17 simulator (26.2), including after notification-layer decoupling. `MainHomeView` query state is ViewModel-owned, and all major navigation/notification payloads are now domain-typed (`FGUserBook`). Phase 1 boundary goal is met; optional follow-up work is additional ViewModel extraction for more complex screens.
+Behavioral parity was validated through repeated `xcodebuild test` runs on iPhone 17 simulator (26.2), including after notification-layer decoupling and a post-merge baseline rerun on 2026-02-13. `MainHomeView` query state is ViewModel-owned, and all major navigation/notification payloads are now domain-typed (`FGUserBook`).
+
+Phase 2 outcome (2026-02-13): action-heavy screens now route through feature ViewModels (`DailyProgressViewModel`, `CompletionReviewViewModel`, `ReadingDateEditViewModel`, `FinishGoalViewModel`, `UnfinishReadingViewModel`, `NotiSettingViewModel`) and no longer execute domain service commands directly in View button handlers. New ViewModel tests were added in `FiveGuyesTests/PresentationViewModelTests.swift`, and full regression tests pass (`** TEST SUCCEEDED **`).
 
 ## Context and Orientation
 
@@ -120,6 +141,20 @@ Milestone 4 migrates completion and date edit flows to service commands (`comple
 Milestone 5 removes legacy runtime calculator usage from migrated flows and consolidates schedule behavior on V2 calculators. Preserve old code only if still needed by untouched screens.
 
 Milestone 6 expands tests: ViewModel state transitions with mocked service, domain service command paths with mock repository, and existing repository tests retained as persistence contract checks.
+
+### Phase 2 (Post-Boundary Hardening) Milestones
+
+Milestone 7 extracts async command/query orchestration out of action-heavy Views into feature ViewModels:
+
+- `DailyProgressView` -> `DailyProgressViewModel`
+- `CompletionReviewView` -> `CompletionReviewViewModel`
+- `ReadingDateEditView` -> `ReadingDateEditViewModel`
+- `FinishGoalView` -> `FinishGoalViewModel`
+- `UnfinishReadingView` -> `UnfinishReadingViewModel`
+
+Milestone 8 introduces notification-settings orchestration in a dedicated ViewModel (`NotiSettingViewModel`) with testable abstraction seams for notification authorization/request updates and local preference persistence.
+
+Milestone 9 adds test coverage for new ViewModels (happy path + failure + duplicate submit/task guard) and keeps existing service/repository tests as regression backstop.
 
 ## Concrete Steps
 
@@ -154,12 +189,14 @@ Acceptance is behavior-first:
 3. Registration flow still saves a new book with an initial schedule and returns to root.
 4. Completion flow still stores completion review and completion status.
 5. Existing calculator and repository tests pass, and new ViewModel tests cover success/failure/loading states.
+6. Notification setting 화면에서 권한/시간/토글 변화 시 기존과 동일한 사용자 동작을 유지한다.
 
 Technical acceptance:
 
 - Migrated views no longer import SwiftData.
 - Migrated views do not call `modelContext.insert/save/delete`.
 - Migrated views do not call legacy `ReadingScheduleCalculator` directly.
+- Phase 2 target Views do not directly call `BookManagementService`/`NotificationManager` in button action handlers; ViewModel methods own async orchestration and submission guards.
 
 ## Idempotence and Recovery
 
@@ -219,3 +256,5 @@ Revision Note (2026-02-12): Migrated `MainHomeView` query state to `MainHomeView
 Revision Note (2026-02-12): Removed duplicate refactoring design memo (`docs/architecture-refactoring.md`) and consolidated canonical records into `ARCHITECTURE.md`, ADR, and this ExecPlan.
 Revision Note (2026-02-12): Re-ran full test suite after latest payload/type migration and confirmed `** TEST SUCCEEDED **`.
 Revision Note (2026-02-12): Completed notification-flow decoupling to `FGUserBook` (`NotiSettingView`, `NotificationManager`, `NotificationType`) and revalidated the full test suite with `** TEST SUCCEEDED **`.
+Revision Note (2026-02-13): Added Phase 2 scope (feature ViewModel extraction + notification setting orchestration + ViewModel tests), recorded clean post-merge baseline verification on `develop`, and aligned acceptance criteria with remaining refactoring risk.
+Revision Note (2026-02-13): Implemented Phase 2 extraction for action-heavy screens and notification settings, introduced notification abstraction seams for testability, added `PresentationViewModelTests`, and verified full suite success on iPhone 17 simulator.

--- a/docs/git/git-convention.md
+++ b/docs/git/git-convention.md
@@ -49,58 +49,7 @@ Examples:
 
 ---
 
-## 3) PR Convention & Workflow
+## 3) Related Docs
 
-### Before Creating a PR
-1. Review the entire commit history (don’t only look at the latest commit).
-2. Review all changes:
-   - `git diff [base-branch]...HEAD`
-
-### PR Writing Rules
-- Write the PR title and description in **Korean**.
-- If `.github/pull_request_template.md` exists, use it as the default PR description format.
-- If the template file does not exist, use the lightweight format below.
-- Recommended: keep commit `type` in English and write the PR title as `<type>: <한글 요약>`  
-  Example: `refactor: 메인 홈 독서 흐름 MVVM 전환`
-
-### Lightweight PR Description (Only when template is missing)
-- `## 작업 내용`
-  - 핵심 변경 사항
-  - 변경 이유
-- `## 테스트`
-  - 수행한 테스트와 결과
-- `## 후속 작업` (optional)
-- `## 리뷰 포인트` (optional)
-- `## 스크린샷` (optional)
-
-### Branch Push Rule
-- For the first push of a new branch, set upstream:
-  - `git push -u origin <branch-name>`
-
----
-
-## 4) PR Review Convention
-
-### Rules
-- Write review comments in **Korean**.
-- Leave all code findings (bugs, regressions, risks) as **inline comments** on PR diff lines.
-- Do **not** leave only top-level PR comments for code findings.
-- Use one finding per comment with a priority tag: `[P0]`, `[P1]`, `[P2]`, `[P3]`.
-- If inline is impossible, leave a top-level comment and explicitly state why inline is not possible.
-- When leaving a top-level review comment (summary or fallback), start the first line with `[Agent Review]`.
-
-### Exception: Reviewing Your Own PR
-- GitHub does not allow `request-changes` on your own PR.
-- In this case, keep all findings as inline comments (same as normal review).
-- Use a top-level `--comment` review only as a summary; do not replace inline findings with top-level-only comments.
-- If you must use top-level comments for a finding, explicitly explain why inline was not possible.
-
-### Required Inline Command (`gh`)
-```bash
-gh api -X POST repos/<org>/<repo>/pulls/<pr-number>/comments \
-  -f body='[P1] Finding...' \
-  -f commit_id=<head-commit-sha> \
-  -f path='path/to/file.swift' \
-  -F line=<line-number> \
-  -f side=RIGHT
-```
+- PR preparation, writing, and review rules are defined in:
+  - `./docs/git/pr-convention.md`

--- a/docs/git/pr-convention.md
+++ b/docs/git/pr-convention.md
@@ -1,0 +1,79 @@
+# PR Convention
+
+## 1) Scope
+
+- This document defines PR preparation, writing, and review rules.
+- Branching and commit rules are defined in:
+  - `./docs/git/git-convention.md`
+
+---
+
+## 2) PR Preparation Workflow
+
+### Before Creating a PR
+1. Review the entire commit history (do not check only the latest commit).
+   - `git log --oneline [base-branch]..HEAD`
+2. Review all changes.
+   - `git diff [base-branch]...HEAD`
+3. Verify the working tree does not include unintended files.
+   - `git status --short`
+
+### Branch Push Rule
+- For the first push of a new branch, set upstream:
+  - `git push -u origin <branch-name>`
+
+---
+
+## 3) PR Writing Rules
+
+- Write the PR title and description in **Korean**.
+- If `.github/pull_request_template.md` exists, use it as the default PR description format.
+- If the template file does not exist, use the lightweight format below.
+- Recommended: keep commit `type` in English and write the PR title as `<type>: <한글 요약>`.
+  - Example: `refactor: 메인 홈 독서 흐름 MVVM 전환`
+
+### Lightweight PR Description (Only when template is missing)
+- `## 작업 내용`
+  - 핵심 변경 사항
+  - 변경 이유
+- `## 테스트`
+  - 수행한 테스트와 결과
+- `## 후속 작업` (optional)
+- `## 리뷰 포인트` (optional)
+- `## 스크린샷` (optional)
+
+---
+
+## 4) PR Review Convention
+
+### Mandatory Review Checklist
+1. Confirm the review target is the latest `HEAD`.
+2. Re-check latest commit and diff right before posting comments.
+3. Review entire commit history and all changed files.
+4. Verify bug/regression/risk points and test evidence.
+5. Leave each finding as an inline comment with priority.
+
+### Rules
+- Write review comments in **Korean**.
+- Leave all code findings (bugs, regressions, risks) as **inline comments** on PR diff lines.
+- Do **not** leave only top-level PR comments for code findings.
+- Use one finding per comment with a priority tag: `[P0]`, `[P1]`, `[P2]`, `[P3]`.
+- If inline is impossible, leave a top-level comment and explicitly state why inline is not possible.
+- When leaving a top-level review comment (summary or fallback), start the first line with `[Agent Review]`.
+- If another agent is actively updating the same PR/branch, refresh to latest `HEAD` before final review submission to avoid stale comments.
+
+### Exception: Reviewing Your Own PR
+- GitHub does not allow `request-changes` on your own PR.
+- In this case, keep all findings as inline comments (same as normal review).
+- Use a top-level `--comment` review only as a summary; do not replace inline findings with top-level-only comments.
+- If you must use top-level comments for a finding, explicitly explain why inline was not possible.
+
+### Required Inline Command (`gh`)
+```bash
+gh api -X POST repos/<org>/<repo>/pulls/<pr-number>/comments \
+  -f body='[P1] Finding...' \
+  -f commit_id=<head-commit-sha> \
+  -f path='path/to/file.swift' \
+  -F line=<line-number> \
+  -f side=RIGHT
+```


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 액션 중심 화면의 비동기 오케스트레이션을 View에서 ViewModel로 분리했습니다.
  - `DailyProgressViewModel`
  - `CompletionReviewViewModel`
  - `ReadingDateEditViewModel`
  - `FinishGoalViewModel`
  - `UnfinishReadingViewModel`
  - `NotiSettingViewModel`
- `NotiSettingView`의 시스템/저장소 의존을 테스트 가능한 seam으로 분리했습니다.
  - `NotificationManaging`
  - `NotificationSettingsStoring`
- `PresentationViewModelTests`를 추가/보강하여 다음 경로를 검증했습니다.
  - 성공 경로
  - 실패 경로
  - 중복 제출(재진입) 가드
  - 알림 시간 변경 연속 호출 시 이전 Task 취소 동작
- ExecPlan(`mvvm-architecture-refactoring-execplan.md`)에 Phase 2 진행/검증 내역을 반영했습니다.
- 협업/리뷰 규칙 문서를 정리했습니다.
  - `docs/git/pr-convention.md` 신설
  - `docs/git/git-convention.md`에서 PR 규칙 분리
  - `AGENTS.md`의 Git/PR 지침 참조 경로 갱신

### 테스트
- `xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:FiveGuyesTests/PresentationViewModelTests`
  - 결과: `TEST SUCCEEDED`
- `xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"`
  - 결과: `TEST SUCCEEDED`

### 스크린샷 (선택)
- UI 레이아웃 변경 없음

## 💬 리뷰 요구사항(선택)
- ViewModel 추출 후 기존 사용자 흐름(저장/완료/뒤로가기)의 동작 동일성 관점 위주로 확인 부탁드립니다.
- `NotiSettingViewModel`의 Task 취소 가드(`Task.isCancelled`) 적용 위치가 적절한지 확인 부탁드립니다.
- 협업 규칙 문서 분리(`git-convention`/`pr-convention`)가 팀 워크플로우에 맞는지 확인 부탁드립니다.
