### PR TITLE
refactor: 도서 검색 플로우 의존성 주입 및 테스트 보강

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,9 @@ When performing PR review, you must:
 
 For source file header rules, follow:
 - `./docs/conventions/file-header-convention.md`
+
+# Change Scope Guard (Mandatory)
+
+- Code changes must be limited strictly to the user-requested scope.
+- Do not modify unrelated files, logic, UI, naming, formatting, or refactors unless explicitly requested.
+- If an out-of-scope change is necessary to complete the requested fix safely, ask the user first and proceed only after approval.

--- a/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
@@ -12,9 +12,13 @@ import SwiftData
 @Observable
 final class AppDependencies {
     let bookManagementService: any BookManagementService
+    let notificationManager: any NotificationManaging
+    let notificationSettingsStore: any NotificationSettingsStoring
 
     init(modelContainer: ModelContainer) {
         let repository = SwiftDataBookRepository(modelContainer: modelContainer)
         self.bookManagementService = DefaultBookManagementService(repository: repository)
+        self.notificationManager = NotificationManager()
+        self.notificationSettingsStore = UserDefaultsNotificationSettingsStore()
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
@@ -14,11 +14,13 @@ final class AppDependencies {
     let bookManagementService: any BookManagementService
     let notificationManager: any NotificationManaging
     let notificationSettingsStore: any NotificationSettingsStoring
+    let bookSearchStore: any BookSearching
 
     init(modelContainer: ModelContainer) {
         let repository = SwiftDataBookRepository(modelContainer: modelContainer)
         self.bookManagementService = DefaultBookManagementService(repository: repository)
         self.notificationManager = NotificationManager()
         self.notificationSettingsStore = UserDefaultsNotificationSettingsStore()
+        self.bookSearchStore = APIStore()
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift
@@ -14,13 +14,22 @@ final class AppDependencies {
     let bookManagementService: any BookManagementService
     let notificationManager: any NotificationManaging
     let notificationSettingsStore: any NotificationSettingsStoring
-    let bookSearchStore: any BookSearching
+    private var cachedBookSearchStore: (any BookSearching)?
 
     init(modelContainer: ModelContainer) {
         let repository = SwiftDataBookRepository(modelContainer: modelContainer)
         self.bookManagementService = DefaultBookManagementService(repository: repository)
         self.notificationManager = NotificationManager()
         self.notificationSettingsStore = UserDefaultsNotificationSettingsStore()
-        self.bookSearchStore = APIStore()
+    }
+
+    func makeBookSearchStore() -> any BookSearching {
+        if let cachedBookSearchStore {
+            return cachedBookSearchStore
+        }
+
+        let store = APIStore()
+        self.cachedBookSearchStore = store
+        return store
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift
@@ -35,7 +35,7 @@ struct FiveGuyesApp: App {
     
     var body: some Scene {
         WindowGroup {
-            NavigationRootView()
+            NavigationRootView(appDependencies: dependencies)
                 .environment(dependencies)
                 .modelContainer(container)
         }

--- a/FiveGuyes/FiveGuyes/Sources/App/NavigationRootView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/App/NavigationRootView.swift
@@ -6,10 +6,17 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct NavigationRootView: View {
-    @State private var coordinator = NavigationCoordinator()
-    
+    @State private var coordinator: NavigationCoordinator
+
+    init(appDependencies: AppDependencies) {
+        _coordinator = State(
+            initialValue: NavigationCoordinator(appDependencies: appDependencies)
+        )
+    }
+
     var body: some View {
         NavigationStack(path: $coordinator.paths) {
             
@@ -24,5 +31,8 @@ struct NavigationRootView: View {
 }
 
 #Preview {
-    NavigationRootView()
+    let container = try! ModelContainer(for: UserBookSchemaV2.UserBookV2.self)
+    let dependencies = AppDependencies(modelContainer: container)
+    NavigationRootView(appDependencies: dependencies)
+        .environment(dependencies)
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionReviewView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookCompletion/CompletionReviewView.swift
@@ -10,18 +10,27 @@ import SwiftUI
 struct CompletionReviewView: View {
     private let placeholder: String = "책 속 한 줄이 남긴 여운은 무엇인가요?"
     
-    @State private var viewModel = CompletionReviewViewModel()
+    @State private var viewModel: CompletionReviewViewModel
     @FocusState private var isFocusedTextEditor: Bool
     @ObservedObject private var keyboardObserver = KeyboardObserver()
     
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(AppDependencies.self) private var appDependencies
     
     // 업데이트 상황을 나타내는 불 변수
     var isUpdateMode: Bool = false
         
     // 외부에서 주입받을 수 있는 책 변수
     let userBook: FGUserBook
+
+    init(
+        isUpdateMode: Bool = false,
+        userBook: FGUserBook,
+        viewModel: CompletionReviewViewModel
+    ) {
+        self.isUpdateMode = isUpdateMode
+        self.userBook = userBook
+        _viewModel = State(initialValue: viewModel)
+    }
     
     var body: some View {
         @Bindable var bindableViewModel = viewModel
@@ -76,7 +85,6 @@ struct CompletionReviewView: View {
         }
         .customNavigationBackButton()
         .onAppear {
-            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
             viewModel.preloadReview(userBook.completionStatus.reviewAfterCompletion)
             isFocusedTextEditor = true
         }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/DailyProgressView.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 struct DailyProgressView: View {
-    @State private var viewModel = DailyProgressViewModel()
+    @State private var viewModel: DailyProgressViewModel
     
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(AppDependencies.self) private var appDependencies
     
     private let alertText = "전체쪽수를 초과해서 작성했어요!"
     private let alertMessage = "끝까지 읽은 게 맞나요?"
@@ -20,7 +19,12 @@ struct DailyProgressView: View {
     
     @FocusState private var isTextTextFieldFocused: Bool
     
-    let userBook: FGUserBook
+    private let userBook: FGUserBook
+
+    init(userBook: FGUserBook, viewModel: DailyProgressViewModel) {
+        self.userBook = userBook
+        _viewModel = State(initialValue: viewModel)
+    }
     
     var body: some View {
         @Bindable var bindableViewModel = viewModel
@@ -107,7 +111,6 @@ struct DailyProgressView: View {
         .navigationTitle("오늘 독서 현황 기록하기")
         .customNavigationBackButton()
         .onAppear {
-            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
             viewModel.preloadPages(userBook: userBook, adjustedToday: adjustedToday)
             isTextTextFieldFocused = true
         }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookProgress/UnfinishReadingView.swift
@@ -9,15 +9,15 @@ import SwiftUI
 
 struct UnfinishReadingView: View {
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(AppDependencies.self) private var appDependencies
 
-    @State private var viewModel = UnfinishReadingViewModel()
+    @State private var viewModel: UnfinishReadingViewModel
     private let userBook: FGUserBook
     
     // MARK: - init
     
-    init(userBook: FGUserBook) {
+    init(userBook: FGUserBook, viewModel: UnfinishReadingViewModel) {
         self.userBook = userBook
+        _viewModel = State(initialValue: viewModel)
     }
     
     var body: some View {
@@ -57,9 +57,6 @@ struct UnfinishReadingView: View {
         .disableNavigationGesture()
         .customNavigationBackButton {
             markBookAsCompletedInBackground()
-        }
-        .onAppear {
-            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
         }
     }
     
@@ -163,5 +160,10 @@ struct UnfinishReadingView: View {
 }
 
 #Preview {
-    UnfinishReadingView(userBook: .dummy)
+    UnfinishReadingView(
+        userBook: .dummy,
+        viewModel: UnfinishReadingViewModel(
+            bookManagementService: DefaultBookManagementService(repository: MockBookRepository())
+        )
+    )
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSearch/BookListView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSearch/BookListView.swift
@@ -68,5 +68,15 @@ struct BookListView: View {
 }
 
 #Preview {
-    BookListView(bookSearchViewModel: BookSearchViewModel())
+    BookListView(
+        bookSearchViewModel: BookSearchViewModel(
+            bookSearchStore: BookSearchStorePreviewStub()
+        )
+    )
+}
+
+private struct BookSearchStorePreviewStub: BookSearching {
+    func fetchBooks(query: String) async throws -> [Book] { [] }
+
+    func fetchBookTotalPages(isbn: String) async throws -> Int { 0 }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSearch/BookSearchView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSearch/BookSearchView.swift
@@ -12,7 +12,11 @@ struct BookSearchView: View {
     @Environment(BookSettingInputModel.self) var bookSettingInputModel: BookSettingInputModel
     @Environment(BookSettingPageModel.self) var pageModel: BookSettingPageModel
     
-    @StateObject private var bookSearchViewModel = BookSearchViewModel()
+    @StateObject private var bookSearchViewModel: BookSearchViewModel
+
+    init(viewModel: BookSearchViewModel) {
+        _bookSearchViewModel = StateObject(wrappedValue: viewModel)
+    }
     
     var body: some View {
         

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSettingsManagerView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSettingsManagerView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 enum BookSettingsPage: Int {
     case bookSearch = 1
@@ -17,6 +18,7 @@ enum BookSettingsPage: Int {
 
 struct BookSettingsManagerView: View {
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
+    @Environment(AppDependencies.self) private var appDependencies
     
     @State private var bookSettingInputModel = BookSettingInputModel()
     @State private var pageModel = BookSettingPageModel()
@@ -99,7 +101,11 @@ struct BookSettingsManagerView: View {
         case .bookPageSetting:
             BookPageSettingView()
         case .bookSettingDone:
-            FinishGoalView()
+            FinishGoalView(
+                viewModel: FinishGoalViewModel(
+                    bookManagementService: appDependencies.bookManagementService
+                )
+            )
         default:
             EmptyView()
         }
@@ -107,6 +113,9 @@ struct BookSettingsManagerView: View {
 }
 
 #Preview {
+    let container = try! ModelContainer(for: UserBookSchemaV2.UserBookV2.self)
+    let dependencies = AppDependencies(modelContainer: container)
     BookSettingsManagerView()
-        .environment(NavigationCoordinator())
+        .environment(NavigationCoordinator(appDependencies: dependencies))
+        .environment(dependencies)
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSettingsManagerView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSettingsManagerView.swift
@@ -97,7 +97,11 @@ struct BookSettingsManagerView: View {
     private var pageView: some View {
         switch BookSettingsPage(rawValue: pageModel.currentPage) {
         case .bookSearch:
-            BookSearchView()
+            BookSearchView(
+                viewModel: BookSearchViewModel(
+                    bookSearchStore: appDependencies.bookSearchStore
+                )
+            )
         case .bookPageSetting:
             BookPageSettingView()
         case .bookSettingDone:

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSettingsManagerView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/BookSettingsManagerView.swift
@@ -99,7 +99,7 @@ struct BookSettingsManagerView: View {
         case .bookSearch:
             BookSearchView(
                 viewModel: BookSearchViewModel(
-                    bookSearchStore: appDependencies.bookSearchStore
+                    bookSearchStore: appDependencies.makeBookSearchStore()
                 )
             )
         case .bookPageSetting:

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/BookSetting/FinishGoalView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 struct FinishGoalView: View {
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
     @Environment(BookSettingInputModel.self) var bookSettingInputModel: BookSettingInputModel
-    @Environment(AppDependencies.self) private var appDependencies
     
-    @State private var viewModel = FinishGoalViewModel()
+    @State private var viewModel: FinishGoalViewModel
+
+    init(viewModel: FinishGoalViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
     
     var body: some View {
         
@@ -162,7 +165,6 @@ struct FinishGoalView: View {
                 
             }
             .onAppear {
-                viewModel.configure(bookManagementService: appDependencies.bookManagementService)
                 viewModel.calculateRecommendedPagesPerDay(
                     startPage: startPage,
                     targetEndPage: totalPages,

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/Main/MainHomeView.swift
@@ -15,19 +15,21 @@ struct MainHomeView: View {
         case noCompletedNoReading
     }
 
-    let notificationManager = NotificationManager()
     let mainAlertMessage = "삭제 후에는 복원할 수 없어요"
     let today = Date().adjustedDate()
 
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(AppDependencies.self) private var appDependencies
 
-    @State private var viewModel = MainHomeViewModel()
+    @State private var viewModel: MainHomeViewModel
     @State private var topSafeAreaInset: CGFloat = 0
     @State private var showReadingBookAlert = false
 
     @State private var activeBookID: UUID?
     @State private var selectedBookIndex: Int?
+
+    init(viewModel: MainHomeViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     private var readingBooks: [FGUserBook] {
         viewModel.readingBooks
@@ -361,27 +363,16 @@ struct MainHomeView: View {
         }
     }
 
-    @MainActor
-    private func setupNotificationsForCurrentBook() async {
-        // 독서 종료일이 제일 가까운 책을 기준으로 노티를 설정합니다.
-        if let currentReadingBook = readingBooks.first {
-            await notificationManager.setupAllNotifications(currentReadingBook)
-        } else {
-            print("노티 설정 실패 ❗️❗️❗️")
-        }
-    }
-
     private func initializeActiveBookID() {
         activeBookID = readingBooks.first?.id
     }
 
     @MainActor
     private func initializeHomeData() async {
-        viewModel.configure(bookManagementService: appDependencies.bookManagementService)
         await viewModel.loadBooks()
         await reassignReadingSchedules()
         trackScreen()
         initializeActiveBookID()
-        await setupNotificationsForCurrentBook()
+        await viewModel.setupNotificationsForCurrentBook()
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/NotiSetting/NotiSettingView.swift
@@ -9,10 +9,14 @@ import SwiftUI
 
 struct NotiSettingView: View {
     @Environment(\.scenePhase) private var scenePhase // 앱 상태 감지
-    
-    @State private var viewModel = NotiSettingViewModel()
-    
+
+    @State private var viewModel: NotiSettingViewModel
     let userBook: FGUserBook?
+
+    init(userBook: FGUserBook?, viewModel: NotiSettingViewModel) {
+        self.userBook = userBook
+        self._viewModel = State(initialValue: viewModel)
+    }
     
     // Toggle 바인딩 변수
     private var isNotificationToggleEnabled: Binding<Bool> {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/View/ReadingCalendar/ReadingDateEditView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 
 struct ReadingDateEditView: View {
     @Environment(NavigationCoordinator.self) var navigationCoordinator: NavigationCoordinator
-    @Environment(AppDependencies.self) private var appDependencies
     
     private let userBook: FGUserBook
     
-    @State private var viewModel = ReadingDateEditViewModel()
+    @State private var viewModel: ReadingDateEditViewModel
     @StateObject private var calendarCellModel: CalendarCellModel
     
     private var adjustedToday: Date
@@ -49,9 +48,10 @@ struct ReadingDateEditView: View {
         }
     }
     
-    init(userBook: FGUserBook) {
+    init(userBook: FGUserBook, viewModel: ReadingDateEditViewModel) {
         self.adjustedToday = Date().adjustedDate()
         self.userBook = userBook
+        _viewModel = State(initialValue: viewModel)
         
         let userSettings = userBook.userSettings
         
@@ -85,9 +85,6 @@ struct ReadingDateEditView: View {
         }
         .navigationTitle("목표기간 수정하기")
         .customNavigationBackButton()
-        .onAppear {
-            viewModel.configure(bookManagementService: appDependencies.bookManagementService)
-        }
     }
     
     private func descriptionText() -> some View {

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/BookSearchViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/BookSearchViewModel.swift
@@ -12,12 +12,15 @@ final class BookSearchViewModel: ObservableObject {
     
     @Published var books = [Book]()
     @Published var selectedBook: Book?
-    
-    private let apiStore = APIStore()
+    private let bookSearchStore: any BookSearching
+
+    init(bookSearchStore: any BookSearching) {
+        self.bookSearchStore = bookSearchStore
+    }
 
     func searchBooks(query: String) async {
         do {
-            let books = try await apiStore.fetchBooks(query: query)
+            let books = try await bookSearchStore.fetchBooks(query: query)
             self.books = books
         } catch {
             print("Failed to fetch books: \(error)")
@@ -26,7 +29,7 @@ final class BookSearchViewModel: ObservableObject {
 
     func fetchBookTotalPages(isbn: String) async -> String {
         do {
-            return try await String(apiStore.fetchBookTotalPages(isbn: isbn))
+            return try await String(bookSearchStore.fetchBookTotalPages(isbn: isbn))
         } catch {
             print("Failed to fetch book details: \(error)")
             return "0"

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/CompletionReviewViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/CompletionReviewViewModel.swift
@@ -20,10 +20,9 @@ final class CompletionReviewViewModel {
     var showEmptyReviewAlert = false
     private(set) var isSubmitting = false
 
-    private var bookManagementService: (any BookManagementService)?
+    private let bookManagementService: any BookManagementService
 
-    func configure(bookManagementService: any BookManagementService) {
-        guard self.bookManagementService == nil else { return }
+    init(bookManagementService: any BookManagementService) {
         self.bookManagementService = bookManagementService
     }
 
@@ -39,8 +38,6 @@ final class CompletionReviewViewModel {
             showEmptyReviewAlert = true
             return .none
         }
-
-        guard let bookManagementService else { return .none }
 
         isSubmitting = true
         defer { isSubmitting = false }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/DailyProgressViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/DailyProgressViewModel.swift
@@ -21,10 +21,9 @@ final class DailyProgressViewModel {
     var showTargetExceededAlert = false
     private(set) var isSubmitting = false
 
-    private var bookManagementService: (any BookManagementService)?
+    private let bookManagementService: any BookManagementService
 
-    func configure(bookManagementService: any BookManagementService) {
-        guard self.bookManagementService == nil else { return }
+    init(bookManagementService: any BookManagementService) {
         self.bookManagementService = bookManagementService
     }
 
@@ -47,7 +46,6 @@ final class DailyProgressViewModel {
 
     func submit(bookId: UUID, readDate: Date) async -> SubmitOutcome {
         guard !isSubmitting else { return .none }
-        guard let bookManagementService else { return .none }
 
         isSubmitting = true
         let pagesRead = pagesToReadToday

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/FinishGoalViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/FinishGoalViewModel.swift
@@ -14,10 +14,9 @@ final class FinishGoalViewModel {
     var pagesPerDay = 0
     private(set) var isSubmitting = false
 
-    private var bookManagementService: (any BookManagementService)?
+    private let bookManagementService: any BookManagementService
 
-    func configure(bookManagementService: any BookManagementService) {
-        guard self.bookManagementService == nil else { return }
+    init(bookManagementService: any BookManagementService) {
         self.bookManagementService = bookManagementService
     }
 
@@ -55,7 +54,6 @@ final class FinishGoalViewModel {
         excludedReadingDays: [Date]
     ) async -> Bool {
         guard !isSubmitting else { return false }
-        guard let bookManagementService else { return false }
 
         isSubmitting = true
         defer { isSubmitting = false }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/MainHomeViewModel.swift
@@ -14,16 +14,18 @@ final class MainHomeViewModel {
     private(set) var readingBooks: [FGUserBook] = []
     private(set) var completedBooks: [FGUserBook] = []
 
-    private var bookManagementService: (any BookManagementService)?
+    private let bookManagementService: any BookManagementService
+    private let notificationManager: any NotificationManaging
 
-    func configure(bookManagementService: any BookManagementService) {
-        guard self.bookManagementService == nil else { return }
+    init(
+        bookManagementService: any BookManagementService,
+        notificationManager: any NotificationManaging
+    ) {
         self.bookManagementService = bookManagementService
+        self.notificationManager = notificationManager
     }
 
     func loadBooks() async {
-        guard let bookManagementService else { return }
-
         do {
             let readingBooks = try await bookManagementService.fetchReadingBooks()
             let completedBooks = try await bookManagementService.fetchCompletedBooks()
@@ -36,8 +38,6 @@ final class MainHomeViewModel {
     }
 
     func deleteBook(id: UUID) async -> Bool {
-        guard let bookManagementService else { return false }
-
         do {
             try await bookManagementService.deleteBook(id: id)
             await loadBooks()
@@ -49,7 +49,6 @@ final class MainHomeViewModel {
     }
 
     func rescheduleOnAppOpen(today: Date) async -> [FGUserBook] {
-        guard let bookManagementService else { return [] }
         guard !readingBooks.isEmpty else { return [] }
 
         let currentBooks = readingBooks
@@ -70,5 +69,11 @@ final class MainHomeViewModel {
 
         await loadBooks()
         return overdueBooks
+    }
+
+    func setupNotificationsForCurrentBook() async {
+        guard let currentReadingBook = readingBooks.first else { return }
+
+        await notificationManager.setupAllNotifications(currentReadingBook)
     }
 }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NavigationCoordinator.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NavigationCoordinator.swift
@@ -23,35 +23,78 @@ enum Screens: Hashable {
 }
 
 @Observable
+@MainActor
 final class NavigationCoordinator {
+    private let appDependencies: AppDependencies
     var paths = NavigationPath()
     private(set) var viewReloadTrigger = UUID()
+
+    init(appDependencies: AppDependencies) {
+        self.appDependencies = appDependencies
+    }
     
     @ViewBuilder
      func navigate(to screen: Screens) -> some View {
          // TODO: 추가되는 뷰 추가하기
         switch screen {
         case .empty: EmptyView()
-        case .mainHome: 
-            MainHomeView()
+        case .mainHome:
+            MainHomeView(
+                viewModel: MainHomeViewModel(
+                    bookManagementService: appDependencies.bookManagementService,
+                    notificationManager: appDependencies.notificationManager
+                )
+            )
         case .notiSetting(book: let book):
-            NotiSettingView(userBook: book)
+            NotiSettingView(
+                userBook: book,
+                viewModel: NotiSettingViewModel(
+                    notificationManager: appDependencies.notificationManager,
+                    settingsStore: appDependencies.notificationSettingsStore
+                )
+            )
         case .bookSettingsManager:
             BookSettingsManagerView()
         case .totalCalendar(books: let books):
             MultiBookProgressView(currentReadingBooks: books)
         case .dailyProgress(book: let book):
-            DailyProgressView(userBook: book)
+            DailyProgressView(
+                userBook: book,
+                viewModel: DailyProgressViewModel(
+                    bookManagementService: appDependencies.bookManagementService
+                )
+            )
         case .completionCelebration(book: let book):
             CompletionCelebrationView(userBook: book)
         case .completionReview(book: let book):
-            CompletionReviewView(userBook: book)
+            CompletionReviewView(
+                userBook: book,
+                viewModel: CompletionReviewViewModel(
+                    bookManagementService: appDependencies.bookManagementService
+                )
+            )
         case .completionReviewUpdate(book: let book):
-            CompletionReviewView(isUpdateMode: true, userBook: book)
+            CompletionReviewView(
+                isUpdateMode: true,
+                userBook: book,
+                viewModel: CompletionReviewViewModel(
+                    bookManagementService: appDependencies.bookManagementService
+                )
+            )
         case .readingDateEdit(book: let book):
-            ReadingDateEditView(userBook: book)
+            ReadingDateEditView(
+                userBook: book,
+                viewModel: ReadingDateEditViewModel(
+                    bookManagementService: appDependencies.bookManagementService
+                )
+            )
         case .unfinishReading(book: let book):
-            UnfinishReadingView(userBook: book)
+            UnfinishReadingView(
+                userBook: book,
+                viewModel: UnfinishReadingViewModel(
+                    bookManagementService: appDependencies.bookManagementService
+                )
+            )
         }
     }
 

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NotiSettingViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/NotiSettingViewModel.swift
@@ -58,8 +58,8 @@ final class NotiSettingViewModel {
     private let nowProvider: () -> Date
 
     init(
-        notificationManager: any NotificationManaging = NotificationManager(),
-        settingsStore: any NotificationSettingsStoring = UserDefaultsNotificationSettingsStore(),
+        notificationManager: any NotificationManaging,
+        settingsStore: any NotificationSettingsStoring,
         nowProvider: @escaping () -> Date = Date.init
     ) {
         self.notificationManager = notificationManager

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/ReadingDateEditViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/ReadingDateEditViewModel.swift
@@ -13,10 +13,9 @@ import Observation
 final class ReadingDateEditViewModel {
     private(set) var isSubmitting = false
 
-    private var bookManagementService: (any BookManagementService)?
+    private let bookManagementService: any BookManagementService
 
-    func configure(bookManagementService: any BookManagementService) {
-        guard self.bookManagementService == nil else { return }
+    init(bookManagementService: any BookManagementService) {
         self.bookManagementService = bookManagementService
     }
 
@@ -28,7 +27,6 @@ final class ReadingDateEditViewModel {
         today: Date
     ) async -> Bool {
         guard !isSubmitting else { return false }
-        guard let bookManagementService else { return false }
 
         isSubmitting = true
         defer { isSubmitting = false }

--- a/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/UnfinishReadingViewModel.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Presentation/ViewModel/UnfinishReadingViewModel.swift
@@ -12,16 +12,14 @@ import Observation
 final class UnfinishReadingViewModel {
     private(set) var isCompleting = false
 
-    private var bookManagementService: (any BookManagementService)?
+    private let bookManagementService: any BookManagementService
 
-    func configure(bookManagementService: any BookManagementService) {
-        guard self.bookManagementService == nil else { return }
+    init(bookManagementService: any BookManagementService) {
         self.bookManagementService = bookManagementService
     }
 
     func completeBook(_ userBook: FGUserBook) async -> Bool {
         guard !isCompleting else { return false }
-        guard let bookManagementService else { return false }
 
         isCompleting = true
         defer { isCompleting = false }

--- a/FiveGuyes/FiveGuyes/Sources/Store/APIStore.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Store/APIStore.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-class APIStore {
+protocol BookSearching {
+    func fetchBooks(query: String) async throws -> [Book]
+    func fetchBookTotalPages(isbn: String) async throws -> Int
+}
+
+class APIStore: BookSearching {
     
     private var apiKey: String
     

--- a/FiveGuyes/FiveGuyesTests/PresentationViewModelTests.swift
+++ b/FiveGuyes/FiveGuyesTests/PresentationViewModelTests.swift
@@ -558,6 +558,70 @@ struct PresentationViewModelTests {
         #expect(notificationManager.updateNotificationCallCount == 1)
     }
 
+    @Test("BookSearchViewModel: 검색 성공 시 목록 갱신")
+    func bookSearch_searchBooks_success_updatesBooks() async {
+        let store = BookSearchStoreStub()
+        let expectedBook = makeAPIBook(title: "테스트 도서")
+        store.fetchBooksResult = [expectedBook]
+        let viewModel = BookSearchViewModel(bookSearchStore: store)
+
+        await viewModel.searchBooks(query: "테스트")
+
+        #expect(viewModel.books.count == 1)
+        #expect(viewModel.books.first?.title == "테스트 도서")
+        #expect(store.fetchBooksQueries == ["테스트"])
+    }
+
+    @Test("BookSearchViewModel: 검색 실패 시 기존 목록 유지")
+    func bookSearch_searchBooks_failure_keepsBooks() async {
+        let store = BookSearchStoreStub()
+        let expectedBook = makeAPIBook(title: "초기 도서")
+        store.fetchBooksResult = [expectedBook]
+        let viewModel = BookSearchViewModel(bookSearchStore: store)
+        await viewModel.searchBooks(query: "초기")
+        store.fetchBooksError = TestError.forced
+
+        await viewModel.searchBooks(query: "실패")
+
+        #expect(viewModel.books.count == 1)
+        #expect(viewModel.books.first?.title == "초기 도서")
+        #expect(store.fetchBooksQueries == ["초기", "실패"])
+    }
+
+    @Test("BookSearchViewModel: 총 페이지 조회 성공 시 문자열 반환")
+    func bookSearch_fetchTotalPages_success() async {
+        let store = BookSearchStoreStub()
+        store.fetchBookTotalPagesResult = 412
+        let viewModel = BookSearchViewModel(bookSearchStore: store)
+
+        let totalPages = await viewModel.fetchBookTotalPages(isbn: "9781234567890")
+
+        #expect(totalPages == "412")
+        #expect(store.fetchTotalPagesISBNs == ["9781234567890"])
+    }
+
+    @Test("BookSearchViewModel: 총 페이지 조회 실패 시 0 반환")
+    func bookSearch_fetchTotalPages_failure_returnsZero() async {
+        let store = BookSearchStoreStub()
+        store.fetchBookTotalPagesError = TestError.forced
+        let viewModel = BookSearchViewModel(bookSearchStore: store)
+
+        let totalPages = await viewModel.fetchBookTotalPages(isbn: "9781234567890")
+
+        #expect(totalPages == "0")
+    }
+
+    @Test("BookSearchViewModel: 책 선택 상태 갱신")
+    func bookSearch_selectBook_updatesSelectedBook() {
+        let store = BookSearchStoreStub()
+        let viewModel = BookSearchViewModel(bookSearchStore: store)
+        let selectedBook = makeAPIBook(title: "선택 도서")
+
+        viewModel.selectBook(selectedBook)
+
+        #expect(viewModel.selectedBook?.title == "선택 도서")
+    }
+
     private func makeBook(id: UUID = UUID(), isCompleted: Bool = false) -> FGUserBook {
         FGUserBook(
             id: id,
@@ -583,6 +647,17 @@ struct PresentationViewModelTests {
                 isCompleted: isCompleted,
                 reviewAfterCompletion: ""
             )
+        )
+    }
+
+    private func makeAPIBook(title: String) -> Book {
+        Book(
+            title: title,
+            author: "테스트 저자",
+            cover: nil,
+            publisher: "테스트 출판사",
+            isbn13: "9781234567890",
+            pubDate: "20250101"
         )
     }
 
@@ -786,5 +861,28 @@ private final class NotificationSettingsStoreStub: NotificationSettingsStoring {
 
     func fetchNotificationReminderTime() -> (hour: Int, minute: Int) {
         (storedReminderHour, storedReminderMinute)
+    }
+}
+
+private final class BookSearchStoreStub: BookSearching {
+    var fetchBooksResult: [Book] = []
+    var fetchBookTotalPagesResult: Int = 0
+
+    var fetchBooksError: Error?
+    var fetchBookTotalPagesError: Error?
+
+    var fetchBooksQueries: [String] = []
+    var fetchTotalPagesISBNs: [String] = []
+
+    func fetchBooks(query: String) async throws -> [Book] {
+        fetchBooksQueries.append(query)
+        if let fetchBooksError { throw fetchBooksError }
+        return fetchBooksResult
+    }
+
+    func fetchBookTotalPages(isbn: String) async throws -> Int {
+        fetchTotalPagesISBNs.append(isbn)
+        if let fetchBookTotalPagesError { throw fetchBookTotalPagesError }
+        return fetchBookTotalPagesResult
     }
 }

--- a/FiveGuyes/FiveGuyesTests/PresentationViewModelTests.swift
+++ b/FiveGuyes/FiveGuyesTests/PresentationViewModelTests.swift
@@ -14,7 +14,8 @@ import Testing
 struct PresentationViewModelTests {
     @Test("DailyProgressViewModel: 목표 초과 입력 시 제출 차단")
     func dailyProgress_overTarget_preventsSubmit() {
-        let viewModel = DailyProgressViewModel()
+        let service = BookManagementServiceStub()
+        let viewModel = DailyProgressViewModel(bookManagementService: service)
         viewModel.pagesToReadToday = 101
 
         let canSubmit = viewModel.requestSubmit(targetEndPage: 100)
@@ -29,8 +30,7 @@ struct PresentationViewModelTests {
         let service = BookManagementServiceStub(book: book)
         service.recordReadingResult = .completed(updatedBook: book)
 
-        let viewModel = DailyProgressViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = DailyProgressViewModel(bookManagementService: service)
         viewModel.pagesToReadToday = 300
 
         let outcome = await viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
@@ -51,8 +51,7 @@ struct PresentationViewModelTests {
         let service = BookManagementServiceStub(book: book)
         service.recordReadingError = TestError.forced
 
-        let viewModel = DailyProgressViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = DailyProgressViewModel(bookManagementService: service)
         viewModel.pagesToReadToday = 120
 
         let outcome = await viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
@@ -72,8 +71,7 @@ struct PresentationViewModelTests {
         service.recordReadingDelayNanoseconds = 80_000_000
         service.recordReadingResult = .recorded(updatedBook: book)
 
-        let viewModel = DailyProgressViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = DailyProgressViewModel(bookManagementService: service)
         viewModel.pagesToReadToday = 10
 
         async let first = viewModel.submit(bookId: book.id, readDate: makeDate("2025-01-03"))
@@ -91,8 +89,7 @@ struct PresentationViewModelTests {
     @Test("CompletionReviewViewModel: 빈 입력이면 경고 표시")
     func completionReview_emptyReview_showsAlert() async {
         let service = BookManagementServiceStub()
-        let viewModel = CompletionReviewViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = CompletionReviewViewModel(bookManagementService: service)
         viewModel.preloadReview("   ")
 
         let outcome = await viewModel.submit(
@@ -113,8 +110,7 @@ struct PresentationViewModelTests {
     func completionReview_updateMode_callsUpdateCommand() async {
         let book = makeBook(isCompleted: true)
         let service = BookManagementServiceStub(book: book)
-        let viewModel = CompletionReviewViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = CompletionReviewViewModel(bookManagementService: service)
         viewModel.preloadReview("수정된 소감")
 
         let outcome = await viewModel.submit(
@@ -137,8 +133,7 @@ struct PresentationViewModelTests {
         let service = BookManagementServiceStub(book: book)
         service.completeBookError = TestError.forced
 
-        let viewModel = CompletionReviewViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = CompletionReviewViewModel(bookManagementService: service)
         viewModel.preloadReview("완독 소감")
 
         let outcome = await viewModel.submit(
@@ -161,8 +156,7 @@ struct PresentationViewModelTests {
         let service = BookManagementServiceStub(book: book)
         service.completeBookDelayNanoseconds = 80_000_000
 
-        let viewModel = CompletionReviewViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = CompletionReviewViewModel(bookManagementService: service)
         viewModel.preloadReview("완독 소감")
 
         async let first = viewModel.submit(
@@ -189,8 +183,7 @@ struct PresentationViewModelTests {
     func readingDateEdit_success() async {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
-        let viewModel = ReadingDateEditViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = ReadingDateEditViewModel(bookManagementService: service)
 
         let isUpdated = await viewModel.submitReadingPlanUpdate(
             bookId: book.id,
@@ -209,8 +202,7 @@ struct PresentationViewModelTests {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
         service.updateReadingPlanError = TestError.forced
-        let viewModel = ReadingDateEditViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = ReadingDateEditViewModel(bookManagementService: service)
 
         let isUpdated = await viewModel.submitReadingPlanUpdate(
             bookId: book.id,
@@ -230,8 +222,7 @@ struct PresentationViewModelTests {
         let service = BookManagementServiceStub(book: book)
         service.updateReadingPlanDelayNanoseconds = 200_000_000
 
-        let viewModel = ReadingDateEditViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = ReadingDateEditViewModel(bookManagementService: service)
 
         let firstTask = Task {
             await viewModel.submitReadingPlanUpdate(
@@ -262,8 +253,7 @@ struct PresentationViewModelTests {
     func finishGoal_registerBook_success() async {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
-        let viewModel = FinishGoalViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = FinishGoalViewModel(bookManagementService: service)
 
         let apiBook = Book(
             title: "테스트 도서",
@@ -292,8 +282,7 @@ struct PresentationViewModelTests {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
         service.registerBookError = TestError.forced
-        let viewModel = FinishGoalViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = FinishGoalViewModel(bookManagementService: service)
 
         let apiBook = Book(
             title: "테스트 도서",
@@ -322,8 +311,7 @@ struct PresentationViewModelTests {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
         service.registerBookDelayNanoseconds = 200_000_000
-        let viewModel = FinishGoalViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = FinishGoalViewModel(bookManagementService: service)
 
         let apiBook = Book(
             title: "테스트 도서",
@@ -365,8 +353,7 @@ struct PresentationViewModelTests {
     func unfinishReading_completeBook_success() async {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
-        let viewModel = UnfinishReadingViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = UnfinishReadingViewModel(bookManagementService: service)
 
         let completed = await viewModel.completeBook(book)
 
@@ -379,8 +366,7 @@ struct PresentationViewModelTests {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
         service.completeBookError = TestError.forced
-        let viewModel = UnfinishReadingViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = UnfinishReadingViewModel(bookManagementService: service)
 
         let completed = await viewModel.completeBook(book)
 
@@ -393,8 +379,7 @@ struct PresentationViewModelTests {
         let book = makeBook()
         let service = BookManagementServiceStub(book: book)
         service.completeBookDelayNanoseconds = 80_000_000
-        let viewModel = UnfinishReadingViewModel()
-        viewModel.configure(bookManagementService: service)
+        let viewModel = UnfinishReadingViewModel(bookManagementService: service)
 
         async let first = viewModel.completeBook(book)
         await Task.yield()
@@ -403,6 +388,64 @@ struct PresentationViewModelTests {
 
         #expect(!second)
         #expect(service.completeBookCallCount == 1)
+    }
+
+    @Test("MainHomeViewModel: 현재 읽는 책 기준으로 알림 재설정")
+    func mainHome_setupNotificationsForCurrentBook() async {
+        let firstBook = makeBook()
+        let secondBook = makeBook()
+        let service = BookManagementServiceStub(book: firstBook)
+        service.fetchReadingBooksResult = [firstBook, secondBook]
+        service.fetchCompletedBooksResult = []
+        let notificationManager = NotificationManagerStub()
+        let viewModel = MainHomeViewModel(
+            bookManagementService: service,
+            notificationManager: notificationManager
+        )
+
+        await viewModel.loadBooks()
+        await viewModel.setupNotificationsForCurrentBook()
+
+        #expect(notificationManager.setupAllNotificationsCallCount == 1)
+        #expect(notificationManager.setupAllNotificationsBookIDs == [firstBook.id])
+    }
+
+    @Test("MainHomeViewModel: 읽는 책이 없으면 알림 재설정 생략")
+    func mainHome_setupNotificationsWithoutReadingBook() async {
+        let service = BookManagementServiceStub()
+        service.fetchReadingBooksResult = []
+        service.fetchCompletedBooksResult = []
+        let notificationManager = NotificationManagerStub()
+        let viewModel = MainHomeViewModel(
+            bookManagementService: service,
+            notificationManager: notificationManager
+        )
+
+        await viewModel.loadBooks()
+        await viewModel.setupNotificationsForCurrentBook()
+
+        #expect(notificationManager.setupAllNotificationsCallCount == 0)
+    }
+
+    @Test("MainHomeViewModel: 목표일 초과 책을 재스케줄 결과로 반환")
+    func mainHome_reschedule_returnsOverdueBooks() async {
+        let overdueBook = makeBook()
+        let service = BookManagementServiceStub(book: overdueBook)
+        service.fetchReadingBooksResult = [overdueBook]
+        service.fetchCompletedBooksResult = []
+        service.rescheduleOnAppOpenError = ScheduleCalculationError.targetDatePassed
+        let notificationManager = NotificationManagerStub()
+        let viewModel = MainHomeViewModel(
+            bookManagementService: service,
+            notificationManager: notificationManager
+        )
+
+        await viewModel.loadBooks()
+        let overdueBooks = await viewModel.rescheduleOnAppOpen(today: makeDate("2025-01-15"))
+
+        #expect(overdueBooks.count == 1)
+        #expect(overdueBooks.first?.id == overdueBook.id)
+        #expect(service.rescheduleOnAppOpenCallCount == 1)
     }
 
     @Test("NotiSettingViewModel: 저장된 설정 로드")
@@ -683,6 +726,7 @@ private final class NotificationManagerStub: NotificationManaging {
     var requestAuthorizationCallCount = 0
     var clearRequestsCallCount = 0
     var setupAllNotificationsCallCount = 0
+    var setupAllNotificationsBookIDs: [UUID] = []
     var updateNotificationCallCount = 0
     var updateNotificationDelayNanoseconds: UInt64 = 0
     var ignoreCancelledCalls = false
@@ -698,6 +742,7 @@ private final class NotificationManagerStub: NotificationManaging {
 
     func setupAllNotifications(_ readingBook: FGUserBook) async {
         setupAllNotificationsCallCount += 1
+        setupAllNotificationsBookIDs.append(readingBook.id)
     }
 
     func updateNotification(notificationType: NotificationType) async {

--- a/docs/execplans/mvvm-architecture-refactoring-execplan.md
+++ b/docs/execplans/mvvm-architecture-refactoring-execplan.md
@@ -37,6 +37,8 @@ The change is observable when the core screens still behave the same in the simu
 - [x] (2026-02-12 18:26Z) Updated `PresentationViewModelTests` for constructor injection and revalidated full suite (`xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"` -> `** TEST SUCCEEDED **`).
 - [x] (2026-02-13 03:31Z) Extended constructor injection/assembly consistency to notification settings flow: `NotiSettingView` no longer self-instantiates `NotiSettingViewModel`, and coordinator now assembles it from `AppDependencies`.
 - [x] (2026-02-13 03:31Z) Revalidated architecture boundary checks (`configure(bookManagementService:)`, presentation `modelContext`/`@Query`/`ReadingScheduleCalculator(`) and full `xcodebuild test` on iPhone 17 (`** TEST SUCCEEDED **`).
+- [x] (2026-02-12 18:53Z) Migrated book search flow to constructor-injected external API seam: `BookSearchViewModel` now depends on `BookSearching`, and `BookSettingsManagerView` assembles it via `AppDependencies.bookSearchStore`.
+- [x] (2026-02-12 18:55Z) Added `BookSearchViewModel` tests (search success/failure, total pages success/failure, selected book state) and revalidated full suite (`xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"` -> `** TEST SUCCEEDED **`).
 
 ## Surprises & Discoveries
 
@@ -72,6 +74,9 @@ The change is observable when the core screens still behave the same in the simu
 
 - Observation: Notification settings remained the last feature flow with in-View ViewModel instantiation after constructor injection migration.
   Evidence: `NotiSettingView` had `@State private var viewModel = NotiSettingViewModel()` while coordinator only passed route payload.
+
+- Observation: `APIStore` requires runtime `API_KEY` resolution in initializer, so previews/tests need explicit stub injection once book search moves to constructor DI.
+  Evidence: `APIStore.init` uses `Bundle.main.object(forInfoDictionaryKey: "API_KEY")` with `fatalError`, and `BookListView` preview now passes `BookSearchStorePreviewStub`.
 
 ## Decision Log
 
@@ -127,6 +132,10 @@ The change is observable when the core screens still behave the same in the simu
   Rationale: 알림 설정 플로우도 동일한 composition root 정책으로 통일해, View/ViewModel 내부의 숨은 concrete 의존성 생성을 제거한다.
   Date/Author: 2026-02-13 / Codex
 
+- Decision: Treat book search as the same composition-root dependency problem and replace `BookSearchViewModel`'s concrete `APIStore` construction with an injected `BookSearching` seam.
+  Rationale: 등록 플로우도 feature ViewModel이 concrete 외부 API 객체를 직접 생성하지 않도록 통일해야 테스트 가능성/교체 가능성이 유지된다.
+  Date/Author: 2026-02-12 / Codex
+
 ## Outcomes & Retrospective
 
 Current outcome: composition root wiring is in place (`AppDependencies` injected at app root), and core write paths in reading/registration/completion/date-edit flows now route through domain service boundaries:
@@ -149,6 +158,8 @@ Phase 3 incremental outcome (2026-02-13): Home entry flow notification setup als
 Phase 4 incremental outcome (2026-02-13): feature ViewModels now receive `BookManagementService` through constructors and are created at navigation/page assembly points, removing runtime `configure(...)` calls from Views. `NavigationCoordinator` is now `@MainActor` to align with dependency/viewmodel isolation rules, and all regression tests still pass.
 
 Phase 5 incremental outcome (2026-02-13): notification settings flow now follows the same constructor injection assembly model as other features. `NotiSettingView` receives a preconfigured `NotiSettingViewModel` from `NavigationCoordinator`, and its dependencies (`NotificationManaging`, `NotificationSettingsStoring`) are provided by `AppDependencies`.
+
+Phase 6 incremental outcome (2026-02-12): book registration search flow now follows constructor injection as well. `BookSearchViewModel` no longer constructs `APIStore` directly, `BookSettingsManagerView` assembles it using `AppDependencies.bookSearchStore`, and dedicated `PresentationViewModelTests` coverage was added for search and total-page query behavior.
 
 ## Context and Orientation
 
@@ -194,6 +205,8 @@ Milestone 10 removes the remaining Home-side notification orchestration from `Ma
 
 Milestone 11 removes post-init ViewModel configuration for book-management flows by adopting constructor injection and coordinator-level ViewModel assembly.
 
+Milestone 12 migrates the book-search flow (`BookSearchViewModel`, `BookSearchView`, `BookSettingsManagerView`) to composition-root-injected search dependency (`BookSearching`) and adds dedicated ViewModel tests for search and total-page lookup behavior.
+
 ## Concrete Steps
 
 Run all commands from repository root `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys`.
@@ -238,6 +251,7 @@ Technical acceptance:
 - `MainHomeView` does not construct `NotificationManager`; notification side effects are triggered only via `MainHomeViewModel`.
 - Views do not call `configure(bookManagementService:)`; affected feature ViewModels are created with dependencies at initialization.
 - `NotiSettingView` does not instantiate `NotiSettingViewModel` directly; coordinator/composition root provides its dependencies.
+- `BookSearchViewModel` does not instantiate `APIStore` directly; book search dependency is injected via `BookSearching`.
 
 ## Idempotence and Recovery
 
@@ -283,6 +297,14 @@ New interfaces to add during implementation:
 
     var bookManagementService: BookManagementService { get }
     var notificationManager: NotificationManaging { get }
+    var bookSearchStore: BookSearching { get }
+
+- Book-search seam in `FiveGuyes/FiveGuyes/Sources/Store/APIStore.swift`:
+
+    protocol BookSearching {
+        func fetchBooks(query: String) async throws -> [Book]
+        func fetchBookTotalPages(isbn: String) async throws -> Int
+    }
 
 - Feature ViewModels (for each migrated flow) that expose:
 
@@ -302,3 +324,4 @@ Revision Note (2026-02-13): Added Phase 2 scope (feature ViewModel extraction + 
 Revision Note (2026-02-13): Implemented Phase 2 extraction for action-heavy screens and notification settings, introduced notification abstraction seams for testability, added `PresentationViewModelTests`, and verified full suite success on iPhone 17 simulator.
 Revision Note (2026-02-13): Completed the next incremental architecture step by moving Home notification setup from `MainHomeView` to `MainHomeViewModel`, extending `AppDependencies` with `NotificationManaging`, adding Home ViewModel tests, and revalidating full suite success.
 Revision Note (2026-02-13): Standardized constructor injection for book-management feature ViewModels, removed `configure` call sites in Views, moved ViewModel assembly to navigation/page construction points, resolved `@MainActor` isolation by annotating `NavigationCoordinator`, and revalidated full suite success.
+Revision Note (2026-02-12): Added the next architecture step for book-registration search flow by introducing `BookSearching` protocol injection in `BookSearchViewModel`, wiring it through `AppDependencies`/`BookSettingsManagerView`, adding `BookSearchViewModel` tests, and revalidating full suite success.

--- a/docs/execplans/mvvm-architecture-refactoring-execplan.md
+++ b/docs/execplans/mvvm-architecture-refactoring-execplan.md
@@ -30,6 +30,13 @@ The change is observable when the core screens still behave the same in the simu
 - [x] (2026-02-13 01:26) Introduced notification settings ViewModel and abstraction seam (`NotiSettingViewModel`, `NotificationManaging`, `NotificationSettingsStoring`) so `NotiSettingView` no longer directly coordinates `NotificationManager`/`UserDefaultsManager`.
 - [x] (2026-02-13 01:28) Added ViewModel-focused tests in `FiveGuyesTests/PresentationViewModelTests.swift` for new action/state paths (daily progress, completion review, date edit, finish goal, unfinish flow, notification settings).
 - [x] (2026-02-13 01:30) Revalidated full test suite (`xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"` -> `** TEST SUCCEEDED **`).
+- [x] (2026-02-12 18:01Z) Moved Home notification setup side effect from `MainHomeView` to `MainHomeViewModel` and injected `NotificationManaging` from `AppDependencies`.
+- [x] (2026-02-12 18:01Z) Added `MainHomeViewModel` test coverage (`setupNotificationsForCurrentBook`, `rescheduleOnAppOpen`) and revalidated full suite (`xcodebuild test ...` -> `** TEST SUCCEEDED **`).
+- [x] (2026-02-12 18:26Z) Replaced remaining `configure(bookManagementService:)` pattern with constructor injection for feature ViewModels (`MainHome`, `DailyProgress`, `CompletionReview`, `ReadingDateEdit`, `UnfinishReading`, `FinishGoal`).
+- [x] (2026-02-12 18:26Z) Moved ViewModel assembly to composition-aware creation points (`NavigationCoordinator`, `BookSettingsManagerView`) and updated navigation root to initialize coordinator with `AppDependencies`.
+- [x] (2026-02-12 18:26Z) Updated `PresentationViewModelTests` for constructor injection and revalidated full suite (`xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"` -> `** TEST SUCCEEDED **`).
+- [x] (2026-02-13 03:31Z) Extended constructor injection/assembly consistency to notification settings flow: `NotiSettingView` no longer self-instantiates `NotiSettingViewModel`, and coordinator now assembles it from `AppDependencies`.
+- [x] (2026-02-13 03:31Z) Revalidated architecture boundary checks (`configure(bookManagementService:)`, presentation `modelContext`/`@Query`/`ReadingScheduleCalculator(`) and full `xcodebuild test` on iPhone 17 (`** TEST SUCCEEDED **`).
 
 ## Surprises & Discoveries
 
@@ -56,6 +63,15 @@ The change is observable when the core screens still behave the same in the simu
 
 - Observation: `@Bindable` local bindings inside computed `some View` properties can require explicit `return` when additional local declarations are present.
   Evidence: `NotiSettingView.timePicker` needed explicit `return VStack { ... }` after introducing `@Bindable var bindableViewModel`.
+
+- Observation: Even after Phase 2, Home entry flow still directly created `NotificationManager` in View, leaving one UI-layer side effect path outside ViewModel test coverage.
+  Evidence: `MainHomeView` had `let notificationManager = NotificationManager()` and called `setupAllNotifications` before this update.
+
+- Observation: Constructor injection from navigation assembly points required actor boundary alignment because dependencies and feature ViewModels are `@MainActor`.
+  Evidence: `NavigationCoordinator.navigate(to:)` triggered main-actor isolation build errors until `NavigationCoordinator` itself was annotated `@MainActor`.
+
+- Observation: Notification settings remained the last feature flow with in-View ViewModel instantiation after constructor injection migration.
+  Evidence: `NotiSettingView` had `@State private var viewModel = NotiSettingViewModel()` while coordinator only passed route payload.
 
 ## Decision Log
 
@@ -99,6 +115,18 @@ The change is observable when the core screens still behave the same in the simu
   Rationale: Noti 설정 흐름의 비동기 상태 전이를 ViewModel 단위에서 테스트하기 위해, 시스템/저장소 호출을 최소 추상화로 분리했다.
   Date/Author: 2026-02-13 / Codex
 
+- Decision: Extend composition root (`AppDependencies`) to provide notification dependency and inject it into `MainHomeViewModel`.
+  Rationale: 홈 진입 시 알림 재설정도 ViewModel 책임으로 이관해 Presentation 계층의 직접 플랫폼 호출을 제거하고 테스트 가능성을 높인다.
+  Date/Author: 2026-02-13 / Codex
+
+- Decision: Standardize feature ViewModel dependency injection to constructor-based creation from coordinator/page assembly points instead of post-init `configure(...)`.
+  Rationale: View lifecycle 시점의 누락/중복 구성 위험을 줄이고, View가 "이미 구성된 ViewModel"만 다루도록 강제해 아키텍처 경계를 명확히 유지한다.
+  Date/Author: 2026-02-13 / Codex
+
+- Decision: Apply the same coordinator-level ViewModel assembly rule to `NotiSettingViewModel` and expose `NotificationSettingsStoring` from `AppDependencies`.
+  Rationale: 알림 설정 플로우도 동일한 composition root 정책으로 통일해, View/ViewModel 내부의 숨은 concrete 의존성 생성을 제거한다.
+  Date/Author: 2026-02-13 / Codex
+
 ## Outcomes & Retrospective
 
 Current outcome: composition root wiring is in place (`AppDependencies` injected at app root), and core write paths in reading/registration/completion/date-edit flows now route through domain service boundaries:
@@ -115,6 +143,12 @@ Current outcome: composition root wiring is in place (`AppDependencies` injected
 Behavioral parity was validated through repeated `xcodebuild test` runs on iPhone 17 simulator (26.2), including after notification-layer decoupling and a post-merge baseline rerun on 2026-02-13. `MainHomeView` query state is ViewModel-owned, and all major navigation/notification payloads are now domain-typed (`FGUserBook`).
 
 Phase 2 outcome (2026-02-13): action-heavy screens now route through feature ViewModels (`DailyProgressViewModel`, `CompletionReviewViewModel`, `ReadingDateEditViewModel`, `FinishGoalViewModel`, `UnfinishReadingViewModel`, `NotiSettingViewModel`) and no longer execute domain service commands directly in View button handlers. New ViewModel tests were added in `FiveGuyesTests/PresentationViewModelTests.swift`, and full regression tests pass (`** TEST SUCCEEDED **`).
+
+Phase 3 incremental outcome (2026-02-13): Home entry flow notification setup also moved behind ViewModel boundary (`MainHomeViewModel.setupNotificationsForCurrentBook`), so `MainHomeView` no longer creates or calls `NotificationManager` directly. Regression behavior was validated with added Home ViewModel tests and a full `xcodebuild test` pass on iPhone 17 simulator.
+
+Phase 4 incremental outcome (2026-02-13): feature ViewModels now receive `BookManagementService` through constructors and are created at navigation/page assembly points, removing runtime `configure(...)` calls from Views. `NavigationCoordinator` is now `@MainActor` to align with dependency/viewmodel isolation rules, and all regression tests still pass.
+
+Phase 5 incremental outcome (2026-02-13): notification settings flow now follows the same constructor injection assembly model as other features. `NotiSettingView` receives a preconfigured `NotiSettingViewModel` from `NavigationCoordinator`, and its dependencies (`NotificationManaging`, `NotificationSettingsStoring`) are provided by `AppDependencies`.
 
 ## Context and Orientation
 
@@ -155,6 +189,10 @@ Milestone 7 extracts async command/query orchestration out of action-heavy Views
 Milestone 8 introduces notification-settings orchestration in a dedicated ViewModel (`NotiSettingViewModel`) with testable abstraction seams for notification authorization/request updates and local preference persistence.
 
 Milestone 9 adds test coverage for new ViewModels (happy path + failure + duplicate submit/task guard) and keeps existing service/repository tests as regression backstop.
+
+Milestone 10 removes the remaining Home-side notification orchestration from `MainHomeView` and migrates it into `MainHomeViewModel` with composition-root injection + ViewModel tests.
+
+Milestone 11 removes post-init ViewModel configuration for book-management flows by adopting constructor injection and coordinator-level ViewModel assembly.
 
 ## Concrete Steps
 
@@ -197,6 +235,9 @@ Technical acceptance:
 - Migrated views do not call `modelContext.insert/save/delete`.
 - Migrated views do not call legacy `ReadingScheduleCalculator` directly.
 - Phase 2 target Views do not directly call `BookManagementService`/`NotificationManager` in button action handlers; ViewModel methods own async orchestration and submission guards.
+- `MainHomeView` does not construct `NotificationManager`; notification side effects are triggered only via `MainHomeViewModel`.
+- Views do not call `configure(bookManagementService:)`; affected feature ViewModels are created with dependencies at initialization.
+- `NotiSettingView` does not instantiate `NotiSettingViewModel` directly; coordinator/composition root provides its dependencies.
 
 ## Idempotence and Recovery
 
@@ -241,6 +282,7 @@ New interfaces to add during implementation:
 - A presentation dependency container in App layer that exposes:
 
     var bookManagementService: BookManagementService { get }
+    var notificationManager: NotificationManaging { get }
 
 - Feature ViewModels (for each migrated flow) that expose:
 
@@ -258,3 +300,5 @@ Revision Note (2026-02-12): Re-ran full test suite after latest payload/type mig
 Revision Note (2026-02-12): Completed notification-flow decoupling to `FGUserBook` (`NotiSettingView`, `NotificationManager`, `NotificationType`) and revalidated the full test suite with `** TEST SUCCEEDED **`.
 Revision Note (2026-02-13): Added Phase 2 scope (feature ViewModel extraction + notification setting orchestration + ViewModel tests), recorded clean post-merge baseline verification on `develop`, and aligned acceptance criteria with remaining refactoring risk.
 Revision Note (2026-02-13): Implemented Phase 2 extraction for action-heavy screens and notification settings, introduced notification abstraction seams for testability, added `PresentationViewModelTests`, and verified full suite success on iPhone 17 simulator.
+Revision Note (2026-02-13): Completed the next incremental architecture step by moving Home notification setup from `MainHomeView` to `MainHomeViewModel`, extending `AppDependencies` with `NotificationManaging`, adding Home ViewModel tests, and revalidating full suite success.
+Revision Note (2026-02-13): Standardized constructor injection for book-management feature ViewModels, removed `configure` call sites in Views, moved ViewModel assembly to navigation/page construction points, resolved `@MainActor` isolation by annotating `NavigationCoordinator`, and revalidated full suite success.


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 아키텍처 리팩토링 후속으로 도서 검색 플로우(`BookSearchViewModel`)의 외부 API 의존성을 `BookSearching` 프로토콜로 분리하고, `AppDependencies` 조립 지점에서 주입하도록 전환했습니다.
- `BookSearchView`/`BookSettingsManagerView`를 생성자 주입 방식으로 정렬해 feature ViewModel 생성 규칙을 통일했습니다.
- `PresentationViewModelTests`에 `BookSearchViewModel` 테스트(검색 성공/실패, 총 페이지 조회 성공/실패, 선택 상태)를 추가했습니다.
- `docs/execplans/mvvm-architecture-refactoring-execplan.md`에 진행 로그/결정/성과를 업데이트했습니다.
- 커밋을 기능 단위로 분리했습니다.
  - `refactor: inject book search dependencies through composition root`
  - `test: add book search viewmodel coverage`
  - `docs: record book search DI milestone in exec plan`
- 테스트:
  - `xcodebuild test -project FiveGuyes/FiveGuyes.xcodeproj -scheme FiveGuyes -destination "platform=iOS Simulator,name=iPhone 17"`
  - 결과: `** TEST SUCCEEDED **`

### 스크린샷 (선택)
<img src="" width="300"/>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- `BookSearching` 경계 위치(`APIStore.swift`)와 `AppDependencies` 노출 방식이 현재 프로젝트의 의존성 조립 규칙에 맞는지 확인 부탁드립니다.
- `BookSearchViewModel`의 실패 시 동작(기존 목록 유지, 페이지 조회 실패 시 "0")이 제품 의도와 맞는지 확인 부탁드립니다.
