### PR TITLE
fix: 로컬 설정 누락으로 인한 Debug/Test 빌드 실패 방지

### DIFF
--- a/FiveGuyes/Config.xcconfig.example
+++ b/FiveGuyes/Config.xcconfig.example
@@ -1,0 +1,4 @@
+// Copy this file to Config.xcconfig and fill in local secrets.
+// This file is safe to commit because it contains placeholders only.
+
+API_KEY = YOUR_ALADIN_API_KEY

--- a/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
+++ b/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj
@@ -237,8 +237,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
-		};
+				shellScript = "if [ \"$CONFIGURATION\" != \"Release\" ]; then\n  echo \"Skipping Crashlytics upload for $CONFIGURATION configuration\"\n  exit 0\nfi\n\nGOOGLE_SERVICE_INFO_PLIST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\nif [ ! -f \"$GOOGLE_SERVICE_INFO_PLIST\" ]; then\n  echo \"Skipping Crashlytics upload: $GOOGLE_SERVICE_INFO_PLIST not found\"\n  exit 0\nfi\n\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+			};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */

--- a/FiveGuyes/GoogleService-Info.plist.example
+++ b/FiveGuyes/GoogleService-Info.plist.example
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>YOUR_FIREBASE_API_KEY</string>
+	<key>GCM_SENDER_ID</key>
+	<string>YOUR_GCM_SENDER_ID</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.example.app</string>
+	<key>PROJECT_ID</key>
+	<string>your-firebase-project-id</string>
+	<key>STORAGE_BUCKET</key>
+	<string>your-firebase-project-id.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:000000000000:ios:0000000000000000000000</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # 2024-MacC-A6-Five-Guys
 🍔🍔🍔🍔🍔
+
+## Local Setup
+- [Local Build Config Setup](docs/setup/local-build-config.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,2 @@
 # 2024-MacC-A6-Five-Guys
 🍔🍔🍔🍔🍔
-
-## Local Setup
-- [Local Build Config Setup](docs/setup/local-build-config.md)

--- a/docs/setup/local-build-config.md
+++ b/docs/setup/local-build-config.md
@@ -1,0 +1,28 @@
+# Local Build Config Setup
+
+This project intentionally ignores local secret files:
+
+- `FiveGuyes/Config.xcconfig`
+- `FiveGuyes/FiveGuyes/GoogleService-Info.plist`
+
+When these files are missing in a fresh checkout/worktree, build or test can fail.
+
+## 1. Create local config files from examples
+
+Run from repository root:
+
+```sh
+cp FiveGuyes/Config.xcconfig.example FiveGuyes/Config.xcconfig
+cp FiveGuyes/GoogleService-Info.plist.example FiveGuyes/FiveGuyes/GoogleService-Info.plist
+```
+
+Then update the copied files with real local values.
+
+## 2. Build behavior for Crashlytics script
+
+The Crashlytics run script now behaves as follows:
+
+- `Debug` / `Test` configurations: script exits early (skip upload).
+- `Release` configuration: script runs normally, and still requires a valid `GoogleService-Info.plist`.
+
+This keeps local development/testing resilient while preserving release-time validation.


### PR DESCRIPTION
## 📝 작업 내용
> worktree/새 체크아웃에서 로컬 설정 파일이 없어도 원인을 빠르게 파악하고, Debug/Test 빌드가 불필요하게 막히지 않도록 안정화했습니다.

- 문제 상황 정리
  - `Config.xcconfig`, `GoogleService-Info.plist`는 `.gitignore` 대상이라 새 환경에서 파일이 비어 있는 상태로 시작됨
  - 기존 설정에서는 Debug/Test에서도 Crashlytics run script가 실행되어 `GOOGLE_APP_ID` 조회 실패로 빌드/테스트가 중단될 수 있었음
- 변경 사항
  - `project.pbxproj`의 Crashlytics 스크립트에 가드 추가
    - `Release`가 아니면 업로드 스킵
    - `GoogleService-Info.plist`가 없으면 스킵 메시지 출력 후 종료
  - `FiveGuyes/Config.xcconfig.example` 추가
  - `FiveGuyes/GoogleService-Info.plist.example` 추가
  - `docs/setup/local-build-config.md` 추가 (로컬 설정 복사/수정 절차 명시)
  - `README.md`에 로컬 설정 문서 링크 추가
- 보안/운영 관점
  - 실제 비밀값 파일은 그대로 ignore 유지
  - 예시 파일만 추적하여 팀 온보딩/재현성 개선

### 스크린샷 (선택)
<img src="" width="300"/>

## 💬 리뷰 요구사항(선택)
> 특히 아래 두 포인트를 중점 확인 부탁드립니다.

- Release에서만 Crashlytics 검증/업로드가 수행되는 정책이 팀 의도와 일치하는지
- 예시 파일/문서 경로가 신규 팀원이 따라가기 충분히 직관적인지
