### PR TITLE
chore: develop 변경사항 main 동기화

### DIFF
--- a/FiveGuyes/FiveGuyes/Sources/Data/RepoImpl/SwiftDataBookRepo.swift
+++ b/FiveGuyes/FiveGuyes/Sources/Data/RepoImpl/SwiftDataBookRepo.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 
+@MainActor
 final class SwiftDataBookRepo: BookRepo {
     typealias SDUserBook = UserBookSchemaV2.UserBookV2
 
@@ -24,7 +25,6 @@ final class SwiftDataBookRepo: BookRepo {
 
     // MARK: - Initial Methods
 
-    @MainActor
     convenience init(modelContainer: ModelContainer) {
         self.init(
             modelContainer: modelContainer,
@@ -34,7 +34,6 @@ final class SwiftDataBookRepo: BookRepo {
         )
     }
 
-    @MainActor
     init(
         modelContainer: ModelContainer,
         migrationUserDefaults: UserDefaults,
@@ -175,7 +174,6 @@ final class SwiftDataBookRepo: BookRepo {
 
     // MARK: - Helper Methods
 
-    @MainActor
     func prewarmReadingRecordKeyMigrationIfNeeded() throws {
         try migrateStorageIfNeeded()
     }

--- a/docs/exec-plans/architecture-debt-issue-plans.md
+++ b/docs/exec-plans/architecture-debt-issue-plans.md
@@ -26,7 +26,8 @@ This plan follows `/Users/zaehorang/.codex/PLANS.md` and is executed with `/User
 - [x] (2026-02-20 11:05Z) TD-034 3차 완화 반영: route 기본 정책 + top override를 coordinator로 중앙화하고 root 단일 host에서 swipe 정책 적용.
 - [x] (2026-02-20 16:20Z) TD-034 4차 완화 반영: legacy back 호출부/no-op modifier를 정리하고 `NavigationCoordinatorTests` 정책 경계 케이스를 보강.
 - [x] (2026-02-20 21:45Z) TD-034 5차 정리 반영: `customNavigationBackButton` 레거시 오버로드 제거 + `navigationRootBackHost()` 네이밍 모디파이어 적용.
-- [ ] Remaining: TD-015, TD-010, TD-034(back 간헐 재현 계측 + RCA), TD-007 잔여(typed key adapter + settings legacy Date 제거 마이그레이션), TD-022 Stage 2(모듈화 스파이크/분리 로드맵), TD-029 analytics 경계 분리.
+- [x] (2026-02-24 08:30Z) SwiftData `ModelContext` off-main 경고 핫픽스(`@MainActor` 경계 보강)와 후속 debt(TD-035/TD-036) tracker 동기화 반영.
+- [ ] Remaining: TD-015, TD-010, TD-034(back 간헐 재현 계측 + RCA), TD-007 잔여(typed key adapter + settings legacy Date 제거 마이그레이션), TD-035(`ModelActor` 전환), TD-022 Stage 2(모듈화 스파이크/분리 로드맵), TD-029 analytics 경계 분리, TD-036(FIAM API 비활성 운영 노이즈 정리).
 
 ## Surprises & Discoveries
 
@@ -104,6 +105,10 @@ This plan follows `/Users/zaehorang/.codex/PLANS.md` and is executed with `/User
   Rationale: 무시되는 인자를 남겨두면 정책 소스를 오해하기 쉬워서, API 계약을 코드 구조와 동일하게 맞추기 위함이다.
   Date/Author: 2026-02-20 / Codex
 
+- Decision: `mainContext` 경고는 저장소 `@MainActor` 경계 보강으로 우선 차단하고, `@ModelActor` 전환은 별도 debt(TD-035)로 분리한다.
+  Rationale: 런타임 안정화가 우선이며, 저장소 격리 구조 전환은 DI/테스트/마이그레이션 경계를 함께 다뤄야 해 별도 사이클이 필요하다.
+  Date/Author: 2026-02-24 / Codex
+
 ## Outcomes & Retrospective
 
 이번 사이클에서 이슈 상태는 다음과 같이 업데이트되었습니다.
@@ -118,6 +123,8 @@ This plan follows `/Users/zaehorang/.codex/PLANS.md` and is executed with `/User
 8. TD-034 4차 완화에서 legacy/no-op 호출 정리와 `NavigationCoordinatorTests` 정책 경계 보강을 반영했다.
 9. TD-034 5차 정리에서 `customNavigationBackButton(action:)` 단일 API 정리와 `navigationRootBackHost()` 네이밍 정합화를 반영했다.
 10. 컴파일 검증은 `xcodebuild ... build` 성공으로 통과했으며, 화면별 swipe 수동 반복 시나리오는 사용자 검증 단계로 남겨둔다.
+11. 2026-02-24 기준으로 `SwiftDataBookRepo` 저장소 경계 `@MainActor` 핫픽스를 반영했고, 구조 개선 과제는 TD-035(`ModelActor` 전환)로 분리 등록했다.
+12. FIAM API 비활성 403 운영 노이즈는 TD-036으로 분리 등록해 Firebase 제품 구성 정책을 후속 결정하기로 했다.
 
 검증 명령:
 
@@ -197,6 +204,8 @@ architecture-first 리베이스에서 반영한 이슈-코드 매핑은 아래�
 4. TD-007 잔여: typed key adapter 확장 + 글로벌 정책 UX 분리 설계.
 5. TD-022 Stage 2: Domain 분리 스파이크와 모듈화 로드맵 문서화.
 6. TD-029: Presentation analytics 호출 경계 분리 로드맵 문서화/착수.
+7. TD-035: `@ModelActor` 기반 저장소 격리 구조 전환 설계/구현.
+8. TD-036: FIAM SDK/콘솔 API 운영 정책 확정(제거 vs 활성화) 및 체크리스트화.
 
 ## Concrete Steps
 
@@ -263,3 +272,4 @@ Plan revision note (2026-02-19): Added TD-034 validation notes (static grep + `x
 Plan revision note (2026-02-20): Added TD-034 route + dynamic override centralization sync (root host single-point swipe policy application).
 Plan revision note (2026-02-20): Added TD-034 stage-2 cleanup sync (legacy/no-op call-site cleanup + NavigationCoordinator policy test hardening).
 Plan revision note (2026-02-20): Added TD-034 final polish sync (legacy back overload removal + root modifier naming alignment).
+Plan revision note (2026-02-24): Added SwiftData `ModelContext` concurrency hotfix sync and registered TD-035(`ModelActor` migration) / TD-036(FIAM 403 operations noise) as remaining architecture debt.

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -13,6 +13,8 @@
   - 독서 UseCase 흐름 리팩토링 유예 -> `TD-031`
   - UI 알럿 인지 E2E 검증 유예 -> `TD-032`
   - Navigation back 버튼 UI 회귀 자동화 유예 -> `TD-033`
+  - SwiftData `mainContext` 동시성 핫픽스 후속 -> `TD-035`
+  - FIAM API 비활성 운영 노이즈 관리 -> `TD-036`
 - 코드 재검증 기준:
   - 본 문서에 남은 항목은 2026-02-18 코드 리뷰 기준 미해결(`Open`/`Partial`)만 포함합니다.
   - 해결 완료 항목은 본 문서에서 제거했고, 이력은 Git 히스토리로 추적합니다.
@@ -293,6 +295,54 @@
   2. 재현 시나리오를 화면별(알림 설정/책 등록 관리자)로 분리해 성공률을 수치화
   3. `TD-033`과 연계해 반복 탭 기반 back 회귀 시나리오 UITest 적용 여부 검토
 
+## TD-035: SwiftData `mainContext` 의존 저장소의 actor 경계 한계 (`ModelActor` 전환 필요)
+
+- Status: Open
+- Context:
+  - `SwiftDataBookRepo`가 `modelContainer.mainContext`를 저장해 모든 fetch/save를 수행합니다.
+  - 2026-02-24 핫픽스로 저장소 경계에 `@MainActor`를 적용해 off-main 경고를 차단했지만, 구조적으로는 메인 actor 의존이 유지됩니다.
+- Risk:
+  - 저장 경로가 메인 actor에 고정되어 확장 시 병목/응답성 저하 가능성이 있습니다.
+  - 새 비동기 경로 추가 시 격리 누락이 재발할 수 있습니다.
+- Target Layer:
+  - `Data/RepoImpl` 저장소 격리 구조(`@ModelActor` 기반)
+- Trigger Condition:
+  - `ModelContext` 격리 경고 재발, 저장 경로 성능 이슈, 저장소 동시성 기능 확장 시
+- Priority:
+  - P2
+- Current Evidence:
+  - `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys/FiveGuyes/FiveGuyes/Sources/Data/RepoImpl/SwiftDataBookRepo.swift`
+  - `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys/FiveGuyes/FiveGuyes/Sources/Data/RepoImpl/SwiftDataBookRepo+Migration.swift`
+  - `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys/FiveGuyes/FiveGuyes/Sources/App/AppDependencies.swift`
+- Suggested Follow-up:
+  1. `@ModelActor` 기반 저장소 타입을 도입해 `mainContext` 직접 의존을 제거
+  2. 마이그레이션 파이프라인(fetch/save)도 actor 경계 내부로 통합
+  3. 저장소 동시성 회귀 테스트(연속 호출/취소/호출 순서)를 보강
+
+## TD-036: FIAM API 비활성 상태에서 SDK 요청(403) 노이즈
+
+- Status: Open
+- Context:
+  - 타깃이 `FirebaseInAppMessaging-Beta`를 링크한 상태에서, 프로젝트 API 비활성 시 런타임 fetch가 403(`SERVICE_DISABLED`)를 반복합니다.
+  - Analytics(GA)는 별도 SDK로 동작하므로, FIAM 운영 정책을 별도로 정리할 필요가 있습니다.
+- Risk:
+  - 반복 에러 로그와 재시도로 운영 로그 신호대잡음비가 악화됩니다.
+  - 불필요 네트워크 요청으로 디버깅 가시성이 저하됩니다.
+- Target Layer:
+  - Firebase 제품 구성/링킹 정책(`FIAM` 사용 여부와 API 활성화 기준)
+- Trigger Condition:
+  - 런타임 로그 정리 필요, FIAM 기능 도입/비도입 결정, 배포 전 관측성 점검 시
+- Priority:
+  - P3
+- Current Evidence:
+  - `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys/FiveGuyes/FiveGuyes.xcodeproj/project.pbxproj`
+  - `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys/FiveGuyes/FiveGuyes/Sources/App/FiveGuyesApp.swift`
+  - `/Users/zaehorang/Documents/Projects/2024-MacC-A6-Five-Guys/FiveGuyes/FiveGuyes.xcodeproj/xcshareddata/xcschemes/FiveGuyes.xcscheme`
+- Suggested Follow-up:
+  1. 정책 확정: `FIAM` 미사용이면 SDK 제거, 사용이면 콘솔 API 활성화
+  2. 팀 운영 문서에 Firebase 제품별 활성화 체크리스트를 추가
+  3. 배포 전 로그 점검 항목에 `FIAM 403` 여부를 포함
+
 ## Recommended Execution Order
 
 1. TD-015: 야간 알림 시간 상수 유효 범위 이탈 (P1)
@@ -301,8 +351,10 @@
 4. TD-025: 검색 응답 경쟁으로 최신 결과 역전 (P2)
 5. TD-026: 완료 in-flight 중 선택 변경 불일치 (P2)
 6. TD-007: 날짜 키 시맨틱/타입 경계 잔여 정리 (P2, Partial)
-7. TD-022: 컴파일 단 경계 강제 2단계(모듈화) (P3, Partial)
-8. TD-031: 독서 UseCase 내부 흐름 리팩토링 유예 항목 (P3)
-9. TD-029: Analytics 경계 분리 (P3)
-10. TD-032: BookSearch 설정 Alert 사용자 인지 경로 UITest 보강 (P3)
-11. TD-033: Navigation back 버튼 분기 UI 회귀 자동화 보강 (P3)
+7. TD-035: SwiftData `mainContext` actor 경계 개선(`ModelActor` 전환) (P2)
+8. TD-022: 컴파일 단 경계 강제 2단계(모듈화) (P3, Partial)
+9. TD-031: 독서 UseCase 내부 흐름 리팩토링 유예 항목 (P3)
+10. TD-029: Analytics 경계 분리 (P3)
+11. TD-036: FIAM API 비활성 운영 노이즈 정리 (P3)
+12. TD-032: BookSearch 설정 Alert 사용자 인지 경로 UITest 보강 (P3)
+13. TD-033: Navigation back 버튼 분기 UI 회귀 자동화 보강 (P3)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- `develop` 브랜치의 최신 변경사항을 `main`에 동기화합니다.
- 포함 핵심: SwiftData `ModelContext` 메인 액터 경계 핫픽스와 기술부채 문서(TD-035/TD-036) 반영.
- 별도 신규 기능 추가 없이 브랜치 동기화 목적의 PR입니다.

## 💬 리뷰 요구사항(선택)
